### PR TITLE
Allow any korrel8r query in panel.

### DIFF
--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -17,7 +17,6 @@ export const getNeighborsGraph = ({ query }: { query?: string } = {}) => {
     method: 'POST',
     body: JSON.stringify({
       start: {
-        class: 'alert:alert',
         queries: query ? [query] : [],
       },
       depth: 5,


### PR DESCRIPTION
Remove `class: alert:alert` from the client request.
Having a fixed class limits the panel to queries starting at an alert.
Korrel8r can deduce the class from the query, so it is not needed.