### PR TITLE
Prevent extraneous Korrel8r API calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /opt/app-root
 
 USER 0
 
+COPY web/package*.json web/
 COPY Makefile Makefile
+RUN make install-frontend
+
 COPY web/ web/
 RUN make build-frontend
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install-frontend-ci-clean: install-frontend-ci
 	cd web && npm cache clean --force
 
 .PHONY: build-frontend
-build-frontend: install-frontend-ci-clean
+build-frontend:
 	cd web && npm run build
 
 .PHONY: start-frontend

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,12 @@ build-image:
 .PHONY: start-forward
 start-forward:
 	./scripts/start-forward.sh
+
+export REGISTRY_ORG?=openshift-observability-ui
+export TAG?=latest
+IMAGE=quay.io/${REGISTRY_ORG}/troubleshooting-panel-console-plugin:${TAG}
+
+.PHONY: deploy
+deploy:				## Build and push image, deploy to cluster using help.
+	PUSH=1 scripts/build-image.sh
+	helm upgrade -i troubleshooting-panel-console-plugin charts/openshift-console-plugin -n troubleshooting-panel-console-plugin --create-namespace --set plugin.image=$(IMAGE)

--- a/charts/openshift-console-plugin/templates/deployment.yaml
+++ b/charts/openshift-console-plugin/templates/deployment.yaml
@@ -36,17 +36,20 @@ spec:
           resources:
             {{- toYaml .Values.plugin.resources | nindent 12 }}
           volumeMounts:
-            - name: {{ template "openshift-console-plugin.certificateSecret" . }}
+            - name: plugin-cert
               readOnly: true
               mountPath: /var/serving-cert
+            - name: plugin-conf
+              readOnly: true
+              mountPath: /etc/plugin
       volumes:
-        - name: {{ template "openshift-console-plugin.certificateSecret" . }}
+        - name: plugin-cert
           secret:
             secretName: {{ template "openshift-console-plugin.certificateSecret" . }}
             defaultMode: 420
         - name: plugin-conf
           configMap:
-            name: {{ template "openshift-console-plugin.pluginConfigName" . }}
+            name: {{ template "openshift-console-plugin.name" . }}
             defaultMode: 420
       restartPolicy: Always
       dnsPolicy: ClusterFirst

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -54,7 +54,7 @@
         "stylelint-config-standard": "^31.0.0",
         "ts-jest": "^29.1.2",
         "ts-loader": "^9.3.1",
-        "ts-node": "^10.8.1",
+        "ts-node": "^10.9.2",
         "typescript": "^4.7.4",
         "webpack": "5.75.0",
         "webpack-cli": "^4.9.2",

--- a/web/package.json
+++ b/web/package.json
@@ -65,7 +65,7 @@
     "stylelint-config-standard": "^31.0.0",
     "ts-jest": "^29.1.2",
     "ts-loader": "^9.3.1",
-    "ts-node": "^10.8.1",
+    "ts-node": "^10.9.2",
     "typescript": "^4.7.4",
     "webpack": "5.75.0",
     "webpack-cli": "^4.9.2",

--- a/web/src/components/Korrel8rPanel.tsx
+++ b/web/src/components/Korrel8rPanel.tsx
@@ -29,7 +29,7 @@ interface Korrel8rPanelProps {
 }
 
 export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps) {
-  const [queryString, setQueryString] = React.useState(initialQueryString);
+  const [queryInputField, setQueryInputField] = React.useState(initialQueryString);
   const [errorMessage, setErrorMessage] = React.useState('');
   const [errorMessageTitle, setErrorMessageTitle] = React.useState('');
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
@@ -41,18 +41,18 @@ export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps
   const [loggingAvailable, loggingAvailableLoading] = usePluginAvailable('logging-view-plugin');
 
   const dispatch = useDispatch();
-  const query: string = useSelector((state: State) => state.plugins?.tp?.get('query'));
+  const savedQuery: string = useSelector((state: State) => state.plugins?.tp?.get('query'));
   const queryResponse: Korrel8rGraphNeighboursResponse = useSelector((state: State) =>
     state.plugins?.tp?.get('queryResponse'),
   );
 
-  if (!query && queryString) {
-    dispatch(setQuery(queryString));
+  if (!savedQuery && queryInputField) {
+    dispatch(setQuery(queryInputField));
   }
 
   const preventQuery = React.useMemo(() => {
-    return !query || netobserveAvailableLoading || loggingAvailableLoading;
-  }, [query, netobserveAvailableLoading, loggingAvailableLoading]);
+    return !savedQuery || netobserveAvailableLoading || loggingAvailableLoading;
+  }, [savedQuery, netobserveAvailableLoading, loggingAvailableLoading]);
 
   const handleError = React.useCallback(
     (error) => {
@@ -83,7 +83,7 @@ export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps
       return;
     }
     setLoadingTrue();
-    const { request, abort } = getNeighborsGraph({ query });
+    const { request, abort } = getNeighborsGraph({ query: savedQuery });
     request()
       .then((response) => {
         const { existingEdges, existingNodes } = parseResults(
@@ -108,7 +108,7 @@ export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps
       abort();
     };
   }, [
-    query,
+    savedQuery,
     dispatch,
     setLoadingFalse,
     setLoadingTrue,
@@ -128,16 +128,18 @@ export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps
             type="text"
             id="queryString"
             name="queryString"
-            value={queryString}
+            value={queryInputField}
             autoResize
-            onChange={(_event, value) => setQueryString(value)}
+            onChange={(_event, value) => setQueryInputField(value)}
           />
         </TextInputGroup>
         <Button
-          isAriaDisabled={!queryString}
+          isAriaDisabled={!queryInputField}
           onClick={() => {
-            dispatch(setQueryResponse({ nodes: [], edges: [] }));
-            dispatch(setQuery(queryString));
+            if (queryInputField !== savedQuery) {
+              dispatch(setQueryResponse({ nodes: [], edges: [] }));
+              dispatch(setQuery(queryInputField));
+            }
           }}
         >
           Query

--- a/web/src/components/Korrel8rPanel.tsx
+++ b/web/src/components/Korrel8rPanel.tsx
@@ -32,10 +32,13 @@ export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps
   const [queryString, setQueryString] = React.useState(initialQueryString);
   const [errorMessage, setErrorMessage] = React.useState('');
   const [errorMessageTitle, setErrorMessageTitle] = React.useState('');
-  const [isLoading, , setLoadingTrue, setLoadingFalse] = useBoolean(false);
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
-  const netobserveAvailable = usePluginAvailable('netobserv-plugin');
-  const loggingAvailable = usePluginAvailable('logging-view-plugin');
+
+  // Start off loading on the first render since the usePluginAvailable hook is async and will start
+  // loading immediately
+  const [isLoading, , setLoadingTrue, setLoadingFalse] = useBoolean(true);
+  const [netobserveAvailable, netobserveAvailableLoading] = usePluginAvailable('netobserv-plugin');
+  const [loggingAvailable, loggingAvailableLoading] = usePluginAvailable('logging-view-plugin');
 
   const dispatch = useDispatch();
   const query: string = useSelector((state: State) => state.plugins?.tp?.get('query'));
@@ -47,63 +50,74 @@ export default function Korrel8rPanel({ initialQueryString }: Korrel8rPanelProps
     dispatch(setQuery(queryString));
   }
 
+  const preventQuery = React.useMemo(() => {
+    return !query || netobserveAvailableLoading || loggingAvailableLoading;
+  }, [query, netobserveAvailableLoading, loggingAvailableLoading]);
+
+  const handleError = React.useCallback(
+    (error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      setLoadingFalse();
+      let displayError: string;
+      try {
+        displayError = JSON.parse(error.message).error;
+        setErrorMessageTitle(t('Korrel8r Error'));
+      } catch (e) {
+        displayError = error.message;
+        setErrorMessageTitle(t('Error Loading Data'));
+      }
+      setErrorMessage(displayError);
+    },
+    [setLoadingFalse, setErrorMessageTitle, setErrorMessage, t],
+  );
+
+  const clearError = React.useCallback(() => {
+    setErrorMessage('');
+    setErrorMessageTitle('');
+    setLoadingFalse();
+  }, [setErrorMessage, setErrorMessageTitle, setLoadingFalse]);
+
   React.useEffect(() => {
-    if (!query) {
+    if (preventQuery) {
       return;
     }
     setLoadingTrue();
     const { request, abort } = getNeighborsGraph({ query });
     request()
       .then((response) => {
-        let existingNodes = response.nodes.filter((node) => {
-          return (
-            node.count > 0 &&
-            (netobserveAvailable || !node.class.startsWith('netflow')) &&
-            (loggingAvailable || !node.class.startsWith('log'))
-          );
-        });
-        existingNodes = existingNodes.map((node) => {
-          return {
-            class: node.class,
-            count: node.count,
-            queries: node.queries.filter((query) => query.count > 0),
-          };
-        });
-        const existingNodeNames = existingNodes.map((node) => node.class);
-        const existingEdges = response.edges
-          ? response.edges.filter(
-              (edge) =>
-                existingNodeNames.includes(edge.start) && existingNodeNames.includes(edge.goal),
-            )
-          : [];
+        const { existingEdges, existingNodes } = parseResults(
+          response,
+          netobserveAvailable,
+          loggingAvailable,
+        );
+
         dispatch(
           setQueryResponse({
             nodes: existingNodes,
             edges: existingEdges,
           }),
         );
-        setLoadingFalse();
-        setErrorMessage('');
-        setErrorMessageTitle('');
+
+        clearError();
       })
       .catch((error) => {
-        // eslint-disable-next-line no-console
-        console.error(error);
-        setLoadingFalse();
-        let displayError: string;
-        try {
-          displayError = JSON.parse(error.message).error;
-          setErrorMessageTitle(t('Korrel8r Error'));
-        } catch (e) {
-          displayError = error.message;
-          setErrorMessageTitle(t('Error Loading Data'));
-        }
-        setErrorMessage(displayError);
+        handleError(error);
       });
     return () => {
       abort();
     };
-  }, [query, dispatch, setLoadingFalse, setLoadingTrue, loggingAvailable, netobserveAvailable, t]);
+  }, [
+    query,
+    dispatch,
+    setLoadingFalse,
+    setLoadingTrue,
+    handleError,
+    preventQuery,
+    clearError,
+    netobserveAvailable,
+    loggingAvailable,
+  ]);
 
   return (
     <>
@@ -192,4 +206,32 @@ const TopologyInfoState: React.FunctionComponent<TopologyInfoStateProps> = ({
       <EmptyStateBody>{text}</EmptyStateBody>
     </EmptyState>
   );
+};
+
+const parseResults = (
+  response: Korrel8rGraphNeighboursResponse,
+  netobserveAvailable: boolean,
+  loggingAvailable: boolean,
+) => {
+  let existingNodes = response.nodes.filter((node) => {
+    return (
+      node.count > 0 &&
+      (netobserveAvailable || !node.class.startsWith('netflow')) &&
+      (loggingAvailable || !node.class.startsWith('log'))
+    );
+  });
+  existingNodes = existingNodes.map((node) => {
+    return {
+      class: node.class,
+      count: node.count,
+      queries: node.queries.filter((query) => query.count > 0),
+    };
+  });
+  const existingNodeNames = existingNodes.map((node) => node.class);
+  const existingEdges = response.edges
+    ? response.edges.filter(
+        (edge) => existingNodeNames.includes(edge.start) && existingNodeNames.includes(edge.goal),
+      )
+    : [];
+  return { existingEdges, existingNodes };
 };

--- a/web/src/hooks/usePluginAvailable.ts
+++ b/web/src/hooks/usePluginAvailable.ts
@@ -1,14 +1,17 @@
 import * as React from 'react';
 import { useBoolean } from './useBoolean';
 
-export const usePluginAvailable = (pluginName: string): boolean => {
+export const usePluginAvailable = (pluginName: string): [boolean, boolean] => {
   const [isPluginAvailable, togglePluginAvailable] = useBoolean(false);
+  const [loading, toggleLoading] = useBoolean(true);
 
   React.useEffect(() => {
-    fetch(`/api/plugins/${pluginName}/plugin-manifest.json`).then(
-      (response) => response.status === 200 && togglePluginAvailable(),
-    );
-  }, [togglePluginAvailable, pluginName]);
+    fetch(`/api/plugins/${pluginName}/plugin-manifest.json`)
+      .then((response) => {
+        return response.status === 200 && togglePluginAvailable();
+      })
+      .finally(toggleLoading);
+  }, [togglePluginAvailable, pluginName, toggleLoading]);
 
-  return isPluginAvailable;
+  return [isPluginAvailable, loading];
 };

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -17,7 +17,6 @@ export const getNeighborsGraph = ({ query }: { query?: string } = {}) => {
     method: 'POST',
     body: JSON.stringify({
       start: {
-        class: 'alert:alert',
         queries: query ? [query] : [],
       },
       depth: 5,


### PR DESCRIPTION
Resolves #17. 

Adds loading status to `usePluginAvailable`, which is then used to prevent the primary korrel8r query until they have finished running.

Refactored the primary useEffect since it was getting very large with a lot of dependencies. I also tried to use a reducer instead but I found the resulting code to be confusing and that it clashes too much with redux. All of the state could be moved into redux to make everything flow through the same reducer, but we are trying to move off of redux going forward and adding extra project logic to redux seemed like a poor idea with that in mind.

Conflicts with #20 so either this or #20 will need a rebase after the other merges.