### PR TITLE
Prevent extra Korrel8r API calls

### DIFF
--- a/web/src/hooks/usePluginAvailable.ts
+++ b/web/src/hooks/usePluginAvailable.ts
@@ -1,14 +1,17 @@
 import * as React from 'react';
 import { useBoolean } from './useBoolean';
 
-export const usePluginAvailable = (pluginName: string): boolean => {
+export const usePluginAvailable = (pluginName: string): [boolean, boolean] => {
   const [isPluginAvailable, togglePluginAvailable] = useBoolean(false);
+  const [loading, toggleLoading] = useBoolean(true);
 
   React.useEffect(() => {
-    fetch(`/api/plugins/${pluginName}/plugin-manifest.json`).then(
-      (response) => response.status === 200 && togglePluginAvailable(),
-    );
-  }, [togglePluginAvailable, pluginName]);
+    fetch(`/api/plugins/${pluginName}/plugin-manifest.json`)
+      .then((response) => {
+        return response.status === 200 && togglePluginAvailable();
+      })
+      .finally(toggleLoading);
+  }, [togglePluginAvailable, pluginName, toggleLoading]);
 
-  return isPluginAvailable;
+  return [isPluginAvailable, loading];
 };


### PR DESCRIPTION
Resolves #17.

Adds loading status to usePluginAvailable, which is then used to prevent the primary korrel8r query until they have finished running.

Refactored the primary useEffect since it was getting very large with a lot of dependencies. I also tried to use a reducer instead but I found the resulting code to be confusing and that it clashes too much with redux. All of the state could be moved into redux to make everything flow through the same reducer, but we are trying to move off of redux going forward and adding extra project logic to redux seemed like a poor idea with that in mind.

I messed up the rebasing the changes from #20 onto #19, so I'm reopening this with a clean/correct git history.