### PR TITLE
feat: add "Focus" button re-calculates correlation from current URL.

### DIFF
--- a/web/locales/en/plugin__troubleshooting-panel-console-plugin.json
+++ b/web/locales/en/plugin__troubleshooting-panel-console-plugin.json
@@ -1,9 +1,9 @@
 {
-  "Correlation Signals": "Correlation Signals",
+  "Correlated Signals": "Correlated Signals",
   "Error Loading Data": "Error Loading Data",
   "Korrel8r Error": "Korrel8r Error",
-  "No Correlation Signals Found": "No Correlation Signals Found",
-  "No correlation signals were found for the given query. Please try a different query.": "No correlation signals were found for the given query. Please try a different query.",
+  "No Correlated Signals Found": "No Correlated Signals Found",
+  "No correlated signals were found for the given query. Please try a different query.": "No correlated signals were found for the given query. Please try a different query.",
   "Open the Troubleshooting Panel": "Open the Troubleshooting Panel",
   "Troubleshooting": "Troubleshooting",
   "Troubleshooting Panel": "Troubleshooting Panel"

--- a/web/src/components/Korrel8rPanel.tsx
+++ b/web/src/components/Korrel8rPanel.tsx
@@ -4,6 +4,7 @@ import {
   TextArea,
   TextInputGroup,
   Title,
+  Tooltip,
   FlexItem,
   EmptyStateHeader,
   EmptyState,
@@ -57,7 +58,18 @@ export default function Korrel8rPanel() {
   return (
     <>
       <FlexItem className="tp-plugin__panel-query-container">
-        <Title headingLevel="h2">{t('Correlation Signals')}</Title>
+        <Title headingLevel="h2">{t('Correlated Signals')}</Title>
+        <Tooltip content="Focus on the current console page.">
+          <Button
+            isAriaDisabled={!korrel8rQueryFromURL}
+            onClick={() => {
+              setQuery(korrel8rQueryFromURL);
+              setResult(null);
+            }}
+          >
+            Focus
+          </Button>
+        </Tooltip>
         <TextInputGroup className="tp-plugin__panel-query-input">
           <TextArea
             type="text"


### PR DESCRIPTION
feat: add "Focus" button to re-start correlation from current URL. #27

Focus button allows two-sided navigation between panel and main console window:

Workflow:
- Open panel (e.g. on an alert screen) shows data correlated to that alert.
- Navigate to other console screens
  - by clicking on nodes in the correlation graph
  - by using any other console links
- Click "Focus" to re-compute the graph, starting from resources in the current console screen.
