### PR TITLE
OU-455: Prevent uncaught error and usage in developer perspective

### DIFF
--- a/web/src/hooks/useTroubleshootingPanel.tsx
+++ b/web/src/hooks/useTroubleshootingPanel.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { Action, ExtensionHook, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  Action,
+  ExtensionHook,
+  useActivePerspective,
+  useModal,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { InfrastructureIcon } from '@patternfly/react-icons';
 import Popover from '../components/Popover';
 import { useBoolean } from './useBoolean';
@@ -13,6 +18,7 @@ const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
   const { isKorrel8rReachable } = useKorrel8r();
   const { korrel8rQueryFromURL } = useURLState();
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
+  const [perspective] = useActivePerspective();
   const launchModal = useModal();
   const dispatch = useDispatch();
   const [isLaunched, , setLaunched] = useBoolean(false);
@@ -22,7 +28,7 @@ const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
 
   const getActions = React.useCallback(
     (queryString = '') => {
-      if (!isKorrel8rReachable) {
+      if (!isKorrel8rReachable || perspective === 'dev') {
         return [];
       }
       const actions = [
@@ -47,7 +53,7 @@ const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
       ];
       return actions;
     },
-    [isLaunched, launchModal, open, setLaunched, t, isKorrel8rReachable],
+    [isLaunched, launchModal, open, setLaunched, t, isKorrel8rReachable, perspective],
   );
 
   const [actions, setActions] = React.useState<Array<Action>>(getActions());

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -9,22 +9,17 @@ export const useURLState = () => {
   const queryParams = useQueryParams();
   const location = useLocation();
 
-  const [allQueryParameters, setAllQueryParameters] = React.useState<QueryParams>(
-    getAllQueryParams(queryParams),
-  );
-  const [korrel8rQueryFromURL, setKorrel8rQueryFromURL] = React.useState<string | undefined>(
-    Korrel8rNodeFactory.fromURL((location.pathname + location.search).slice(1))?.toQuery(),
-  );
+  const allQueryParameters = React.useMemo(() => getAllQueryParams(queryParams), [queryParams]);
 
-  React.useEffect(() => {
-    const allQueryParametersValue = getAllQueryParams(queryParams);
-    const korrel8rQueryFromURLValue = Korrel8rNodeFactory.fromURL(
-      (location.pathname + location.search).slice(1),
-    )?.toQuery();
-
-    setAllQueryParameters(allQueryParametersValue);
-    setKorrel8rQueryFromURL(korrel8rQueryFromURLValue);
-  }, [queryParams, location.pathname, location.search]);
+  const korrel8rQueryFromURL = React.useMemo(() => {
+    try {
+      return Korrel8rNodeFactory.fromURL((location.pathname + location.search).slice(1)).toQuery();
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      return null;
+    }
+  }, [location.pathname, location.search]);
 
   return {
     allQueryParameters,


### PR DESCRIPTION
The action creation uses the key 'alert-detail-toolbar-actions' to add add the "Troubleshooting Panel" button to the alerts detail page. However, the developer perspective also uses that key to retrieve actions. This led to an unexpected URL being parsed, causing an uncaught error.

This PR looks to prevent an uncaught error and prevent the developer perspective from having access to the troubleshooting panel button.

It also refactors two useState's + a useEffect into two useMemo's since they are only being used as computed values.

Of note this PR adds a console.error whenever the URL fails to get parsed, which may be incorrect. I can see the value in knowing why something failed when trying to debug, but also it may be providing extraneous information and filling up the console with errors when it isn't relevant most of the time.