### PR TITLE
OU-457: Fix Netflow Class Korrel8r Queries

### DIFF
--- a/web/src/korrel8r/k8s.ts
+++ b/web/src/korrel8r/k8s.ts
@@ -125,8 +125,9 @@ export class K8sNode extends Korrel8rNode {
         (model) => model.kind === groupVersionKind.kind && model.verbs.includes('watch'),
       );
     }
-    if (!models || models.length !== 1) {
-      throw new NodeError('Unable to isolate a single model');
+
+    if (!models) {
+      throw new NodeError('Unable to find a matching model');
     }
     const model = models[0];
     if (!groupVersionKind.version) {


### PR DESCRIPTION
When manually creating a netflow query, it returns a Kubernetes Node as one of the nodes in the correlation graph. When we query for the the kubernetes node [GVK](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) there are two separate GVK's that are returned. The old code had previously interpreted this as a failure to parse the query, and then placed a null in the array which then threw an error when the id parameter was retrieved from it.

This PR adds two seperate changes:
1. Use the first GVK returned if multiple are returned
2. Skip nodes that fail to be parsed. Then skip edges for these skipped nodes. 
