### PR TITLE
OU-457: Update Netflow URL to add filter query parameter

### DIFF
--- a/web/src/__tests__/netflow-node.spec.ts
+++ b/web/src/__tests__/netflow-node.spec.ts
@@ -6,19 +6,46 @@ import { NetflowNode } from '../korrel8r/netflow';
  * https://github.com/korrel8r/korrel8r/blob/main/pkg/domains/netflow/netflow.go
  */
 describe('Test NetflowNode Parsing', () => {
-  it('URL => Query => URL', () => {
+  it('URL => Query => URL => Query', () => {
     const url =
-      'netflow-traffic?q={SrcK8S_Type="Pod", SrcK8S_Namespace="myNamespace"}|json&tenant=network';
+      'netflow-traffic?q={SrcK8S_Type="Pod", SrcK8S_Namespace="myNamespace"}|json&tenant=network&timeRange=300&limit=5&filters=src_kind="Pod";src_namespace="myNamespace"';
     const expectedQuery = 'netflow:network:{SrcK8S_Type="Pod", SrcK8S_Namespace="myNamespace"}';
     const actualQuery = NetflowNode.fromURL(url)?.toQuery();
+
+    // The original URL contains extra parameters that we don't want to match on, so do an extra
+    // loop to check that the query is the same
+    const intermediaryURL = NetflowNode.fromQuery(expectedQuery)?.toURL();
+    const secondaryQuery = NetflowNode.fromURL(intermediaryURL)?.toQuery();
     expect(actualQuery).toEqual(expectedQuery);
-    expect(NetflowNode.fromQuery(expectedQuery)?.toURL()).toEqual(url);
+    expect(actualQuery).toEqual(secondaryQuery);
+  });
+  it('URL => Query => URL => Query', () => {
+    const url =
+      'netflow-traffic?q={SrcK8S_Namespace="netobserv"}|json&tenant=network&filters=src_namespace="netobserv"';
+    const expectedQuery = 'netflow:network:{SrcK8S_Namespace="netobserv"}';
+    const actualQuery = NetflowNode.fromURL(url)?.toQuery();
+
+    // The original URL contains extra parameters that we don't want to match on, so do an extra
+    // loop to check that the query is the same
+    const intermediaryURL = NetflowNode.fromQuery(expectedQuery)?.toURL();
+    const secondaryQuery = NetflowNode.fromURL(intermediaryURL)?.toQuery();
+    expect(actualQuery).toEqual(expectedQuery);
+    expect(actualQuery).toEqual(secondaryQuery);
   });
 
   it('Query => URL => Query', () => {
     const query = 'netflow:network:{SrcK8S_Type="Pod", SrcK8S_Namespace="myNamespace"}';
     const expectedURL =
-      'netflow-traffic?q={SrcK8S_Type="Pod", SrcK8S_Namespace="myNamespace"}|json&tenant=network';
+      'netflow-traffic?q={SrcK8S_Type="Pod", SrcK8S_Namespace="myNamespace"}|json&tenant=network&filters=src_kind="Pod";src_namespace="myNamespace"';
+    const actualURL = NetflowNode.fromQuery(query)?.toURL();
+    expect(actualURL).toEqual(expectedURL);
+    expect(NetflowNode.fromURL(actualURL)?.toQuery()).toEqual(query);
+  });
+
+  it('Test Query negation parsing', () => {
+    const query = 'netflow:network:{SrcK8S_Type!="Pod", SrcK8S_Namespace!="myNamespace"}';
+    const expectedURL =
+      'netflow-traffic?q={SrcK8S_Type!="Pod", SrcK8S_Namespace!="myNamespace"}|json&tenant=network&filters=src_kind!="Pod";src_namespace!="myNamespace"';
     const actualURL = NetflowNode.fromQuery(query)?.toURL();
     expect(actualURL).toEqual(expectedURL);
     expect(NetflowNode.fromURL(actualURL)?.toQuery()).toEqual(query);
@@ -72,6 +99,18 @@ describe('Test NetflowNode Parsing', () => {
       {
         query: 'netflow:network:{}',
         expected: 'Expected more than 0 relevant query parameters',
+      },
+      {
+        query: 'netflow:network:{SrcK8S_Type="Pod"=wrong}',
+        expected: 'Expected filter to be in the format key=value',
+      },
+      {
+        query: 'netflow:network:{SrcK8S_Type}',
+        expected: 'Expected filter to be in the format key=value',
+      },
+      {
+        query: 'netflow:network:{InvalidKey="Pod"}',
+        expected: 'Unknown filter key: InvalidKey',
       },
     ].forEach(({ query, expected }) => {
       expect(() => NetflowNode.fromQuery(query)).toThrow(expected);

--- a/web/src/components/Korrel8rTopology.tsx
+++ b/web/src/components/Korrel8rTopology.tsx
@@ -156,9 +156,17 @@ export const Korrel8rTopology: React.FC<{
 
   const selectedIds = React.useMemo(() => {
     return nodes
-      .filter(
-        (node) => '/' + node.data.korrel8rNode?.toURL() === location.pathname + location.search,
-      )
+      .filter((node) => {
+        try {
+          // This is less efficient, but there are certain plugins which add query params
+          // to the URL that we don't want to match on
+          const currentURL = location.pathname + location.search;
+          const currentQuery = Korrel8rNodeFactory.fromURL(currentURL.slice(1))?.toQuery();
+          return node.data.korrel8rNode.toQuery() === currentQuery;
+        } catch (e) {
+          return false;
+        }
+      })
       .map((node) => node.id);
   }, [nodes, location.pathname, location.search]);
 


### PR DESCRIPTION
The Netflow URL's generated from the Korrel8r queries are missing the filter query parameter. The Korrel8r query is only a logql query and can be parsed simply, but before #27 can be merged, the filters => Korrel8r query transformation will need to be looked at, as they have a complex query language built into their filters, much of which Korrel8r doesn't support. 

The selected node check added another loop to prevent extra parameters added by a page from stopping a match. For example, if the page adds an additional query parameter of `timeRange` the logic will now still be able to match and highlight the node