### PR TITLE
fix(OU-467): refactor and simplify panel logic to fix races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export TAG?=latest
 IMAGE=quay.io/${REGISTRY_ORG}/troubleshooting-panel-console-plugin:${TAG}
 
 .PHONY: deploy
-deploy:				## Build and push image, reinstall on cluster using helm.
+deploy:	lint-frontend		## Build and push image, reinstall on cluster using helm.
 	helm uninstall troubleshooting-panel-console-plugin -n troubleshooting-panel-console-plugin || true
 	PUSH=1 scripts/build-image.sh
 	helm install troubleshooting-panel-console-plugin charts/openshift-console-plugin -n troubleshooting-panel-console-plugin --create-namespace --set plugin.image=$(IMAGE)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The development server of the troubleshooting panel can either be ran as a nodej
 
 In one terminal window, run:
 
-1. `make install`
+1. `make install-frontend`
 2. `make start-frontend`
    The plugin HTTP server runs on port 9002 with CORS enabled.
 

--- a/web/src/components/Popover.tsx
+++ b/web/src/components/Popover.tsx
@@ -5,10 +5,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Button, Title, Flex, FlexItem } from '@patternfly/react-core';
 import { TimesCircleIcon } from '@patternfly/react-icons';
 import { State } from '../redux-reducers';
-import { closeTP, setQuery, setQueryResponse } from '../redux-actions';
+import { closeTP } from '../redux-actions';
 import { useTranslation } from 'react-i18next';
 
-export default function Popover(props: { queryString: string }) {
+export default function Popover() {
   const dispatch = useDispatch();
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
 
@@ -16,8 +16,6 @@ export default function Popover(props: { queryString: string }) {
 
   const close = React.useCallback(() => {
     dispatch(closeTP());
-    dispatch(setQuery(''));
-    dispatch(setQueryResponse({ nodes: [], edges: [] }));
   }, [dispatch]);
 
   if (!isOpen) {
@@ -47,7 +45,7 @@ export default function Popover(props: { queryString: string }) {
           grow={{ default: 'grow' }}
           gap={{ default: 'gapNone' }}
         >
-          <Korrel8rPanel initialQueryString={props.queryString} />
+          <Korrel8rPanel />
         </Flex>
       </Flex>
     </>

--- a/web/src/hooks/useTroubleshootingPanel.tsx
+++ b/web/src/hooks/useTroubleshootingPanel.tsx
@@ -26,40 +26,37 @@ const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
     dispatch(openTP());
   }, [dispatch]);
 
-  const getActions = React.useCallback(
-    (queryString = '') => {
-      if (!isKorrel8rReachable || perspective === 'dev') {
-        return [];
-      }
-      const actions = [
-        {
-          id: 'open-troubleshooting-panel',
-          label: (
-            <div title={t('Open the Troubleshooting Panel')}>
-              <InfrastructureIcon /> {t('Troubleshooting Panel')}
-            </div>
-          ),
-          description: t('Open the Troubleshooting Panel'),
-          cta: () => {
-            if (!isLaunched && launchModal) {
-              launchModal?.(Popover, { queryString });
-              setLaunched();
-            }
-            open();
-          },
-          disabled: false,
-          tooltip: t('Open the Troubleshooting Panel'),
+  const getActions = React.useCallback(() => {
+    if (!isKorrel8rReachable || perspective === 'dev') {
+      return [];
+    }
+    const actions = [
+      {
+        id: 'open-troubleshooting-panel',
+        label: (
+          <div title={t('Open the Troubleshooting Panel')}>
+            <InfrastructureIcon /> {t('Troubleshooting Panel')}
+          </div>
+        ),
+        description: t('Open the Troubleshooting Panel'),
+        cta: () => {
+          if (!isLaunched && launchModal) {
+            launchModal?.(Popover, {});
+            setLaunched();
+          }
+          open();
         },
-      ];
-      return actions;
-    },
-    [isLaunched, launchModal, open, setLaunched, t, isKorrel8rReachable, perspective],
-  );
+        disabled: false,
+        tooltip: t('Open the Troubleshooting Panel'),
+      },
+    ];
+    return actions;
+  }, [isLaunched, launchModal, open, setLaunched, t, isKorrel8rReachable, perspective]);
 
   const [actions, setActions] = React.useState<Array<Action>>(getActions());
 
   React.useEffect(() => {
-    setActions(getActions(korrel8rQueryFromURL));
+    setActions(getActions());
   }, [korrel8rQueryFromURL, isLaunched, launchModal, open, setLaunched, getActions]);
 
   return [actions, true, null];

--- a/web/src/redux-actions.ts
+++ b/web/src/redux-actions.ts
@@ -1,24 +1,16 @@
 import { action, ActionType as Action } from 'typesafe-actions';
-import { Korrel8rGraphNeighboursResponse } from './korrel8r/query.types';
 
 export enum ActionType {
   CloseTP = 'closeTP',
   OpenTP = 'openTP',
-  SetQuery = 'setQuery',
-  SetQueryResponse = 'setQueryResponse',
 }
 
 export const closeTP = () => action(ActionType.CloseTP);
 export const openTP = () => action(ActionType.OpenTP);
-export const setQuery = (query: string) => action(ActionType.SetQuery, { query });
-export const setQueryResponse = (queryResponse: Korrel8rGraphNeighboursResponse) =>
-  action(ActionType.SetQueryResponse, { queryResponse });
 
 const actions = {
   closeTP,
   openTP,
-  setQuery,
-  setQueryResponse,
 };
 
 export type TPAction = Action<typeof actions>;

--- a/web/src/redux-reducers.ts
+++ b/web/src/redux-reducers.ts
@@ -30,14 +30,6 @@ const reducer = (state: TPState, action: TPAction): TPState => {
     case ActionType.OpenTP:
       return state.set('isOpen', true);
 
-    case ActionType.SetQuery:
-      return state.set('query', action.payload.query);
-    case ActionType.SetQueryResponse:
-      return state.set('queryResponse', {
-        nodes: [...action.payload.queryResponse.nodes],
-        edges: [...action.payload.queryResponse.edges],
-      });
-
     default:
       break;
   }


### PR DESCRIPTION
See https://issues.redhat.com/browse/OU-476
Repeating the same query gave different results, sometimes success, sometimes a JSON parsing error.

Refactored Korrle8rPanel logic to simplify and remove race conditions:

- No props passed to Korrle8rPanel, initialize from context URL.
- useState only for query and result, no redux or dispatch. There is no need to share state with other components.
- Single atomic state variable for result: holds graph or error.
- Don't check other plugin availability, let korrel8r determine what is available at runtime.
- Don't filter results, assume korrel8r will return correct results.
- Always run query even if it hasn't changed - simpler logic + the cluster state may have changed.