### PR TITLE
feat: Advanced query controls, fixes #40

### DIFF
--- a/web/locales/en/plugin__troubleshooting-panel-console-plugin.json
+++ b/web/locales/en/plugin__troubleshooting-panel-console-plugin.json
@@ -1,10 +1,20 @@
 {
-  "Correlated Signals": "Correlated Signals",
+  "Correlation result was empty.": "Correlation result was empty.",
   "Error Loading Data": "Error Loading Data",
+  "Find related resources.": "Find related resources.",
+  "Focus": "Focus",
+  "Goal class: ": "Goal class: ",
+  "Hide Query": "Hide Query",
+  "Korrel8 query selecting the starting points for correlation.": "Korrel8 query selecting the starting points for correlation.",
   "Korrel8r Error": "Korrel8r Error",
+  "Neighbourhood depth: ": "Neighbourhood depth: ",
   "No Correlated Signals Found": "No Correlated Signals Found",
-  "No correlated signals were found for the given query. Please try a different query.": "No correlated signals were found for the given query. Please try a different query.",
   "Open the Troubleshooting Panel": "Open the Troubleshooting Panel",
+  "Query": "Query",
+  "Re-calculate the correlation graph starting from resources on the current console page.": "Re-calculate the correlation graph starting from resources on the current console page.",
+  "Show graph of connected classes up to the specified depth.": "Show graph of connected classes up to the specified depth.",
+  "Show graph of paths to signals of the specified class.": "Show graph of paths to signals of the specified class.",
+  "Show Query": "Show Query",
   "Troubleshooting": "Troubleshooting",
-  "Troubleshooting Panel": "Troubleshooting Panel"
+  "Troubleshooting Panel": "Troubleshooting Panel",
 }

--- a/web/src/components/Korrel8rPanel.tsx
+++ b/web/src/components/Korrel8rPanel.tsx
@@ -1,31 +1,41 @@
 import * as React from 'react';
+import { CancellableFetch } from '../cancellable-fetch';
 import {
   Button,
-  TextArea,
-  TextInputGroup,
-  Title,
-  Tooltip,
-  FlexItem,
-  EmptyStateHeader,
+  Divider,
   EmptyState,
   EmptyStateBody,
-  EmptyStateVariant,
+  EmptyStateHeader,
   EmptyStateIcon,
+  EmptyStateVariant,
+  ExpandableSection,
+  ExpandableSectionToggle,
+  Flex,
+  FlexItem,
+  NumberInput,
+  Radio,
+  TextArea,
+  TextInput,
+  Tooltip,
 } from '@patternfly/react-core';
 import { Korrel8rTopology } from './Korrel8rTopology';
 import './korrel8rpanel.css';
-import { getNeighborsGraph } from '../korrel8r-client';
-import { Korrel8rGraphNeighboursResponse } from '../korrel8r/query.types';
+import { getGoalsGraph, getNeighborsGraph } from '../korrel8r-client';
+import { Korrel8rGraphResponse } from '../korrel8r/query.types';
 import { LoadingTopology } from './LoadingTopology';
 import { TFunction, useTranslation } from 'react-i18next';
 import { CubesIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useURLState } from '../hooks/useURLState';
 
 type Result = {
-  graph?: Korrel8rGraphNeighboursResponse;
+  graph?: Korrel8rGraphResponse;
   message?: string;
   title?: string;
 };
+enum QueryType {
+  Neighbour,
+  Goal,
+}
 
 export default function Korrel8rPanel() {
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
@@ -34,18 +44,30 @@ export default function Korrel8rPanel() {
   const { korrel8rQueryFromURL } = useURLState();
   const [query, setQuery] = React.useState(korrel8rQueryFromURL);
   const [result, setResult] = React.useState<Result | null>(null);
+  const [showQuery, setShowQuery] = React.useState(false);
+  const [queryType, setQueryType] = React.useState(QueryType.Neighbour);
+  const [depth, setDepth] = React.useState(3);
+  const [goal, setGoal] = React.useState('');
 
   React.useEffect(() => {
     // Set result = null to trigger a reload, don't run the query till then.
     if (result !== null) {
       return;
     }
-    const { request, abort } = getNeighborsGraph({ query });
+    let fetch: CancellableFetch<Korrel8rGraphResponse>;
+    if (queryType === QueryType.Neighbour) {
+      fetch = getNeighborsGraph({ query }, depth);
+    } else if (queryType === QueryType.Goal) {
+      fetch = getGoalsGraph({ query }, goal);
+    } else {
+      return;
+    }
+    const { request, abort } = fetch;
     request()
-      .then((response) => {
+      .then((response: Korrel8rGraphResponse) => {
         setResult({ graph: { nodes: response.nodes, edges: response.edges } });
       })
-      .catch((e) => {
+      .catch((e: Error) => {
         try {
           setResult({ message: JSON.parse(e.message).error, title: t('Korrel8r Error') });
         } catch {
@@ -53,42 +75,123 @@ export default function Korrel8rPanel() {
         }
       });
     return abort;
-  }, [result, query, t]);
+  }, [result, query, depth, goal, queryType, t]);
+
+  const queryToggleID = 'query-toggle';
+  const queryContentID = 'query-content';
+  const queryInputID = 'query-input';
+  const queryTypeOptions = 'query-type-options';
+
+  const cannotFocus = t(
+    'The current console page does not show resources that are supported for correlation.',
+  );
+  const focusTip = korrel8rQueryFromURL
+    ? t('Re-calculate the correlation graph starting from resources on the current console page.')
+    : cannotFocus;
+  const minDepth = 1;
+  const maxDepth = 10;
+  const runQuery = () => {
+    if (!goal) setQueryType(QueryType.Neighbour); // If no goal do neighbours.
+    if (!depth || depth < minDepth) setDepth(minDepth); // Min valid value is 1
+    if (depth && depth > maxDepth) setDepth(maxDepth); // Max value
+    setResult(null);
+  };
 
   return (
     <>
-      <FlexItem className="tp-plugin__panel-query-container">
-        <Title headingLevel="h2">{t('Correlated Signals')}</Title>
-        <Tooltip content="Focus on the current console page.">
+      <Flex className="tp-plugin__panel-query-container">
+        <Tooltip content={focusTip}>
           <Button
             isAriaDisabled={!korrel8rQueryFromURL}
             onClick={() => {
               setQuery(korrel8rQueryFromURL);
-              setResult(null);
+              runQuery();
             }}
           >
-            Focus
+            {t('Focus')}
           </Button>
         </Tooltip>
-        <TextInputGroup className="tp-plugin__panel-query-input">
-          <TextArea
-            type="text"
-            id="queryString"
-            name="queryString"
-            value={query}
-            autoResize
-            onChange={(_event, value) => setQuery(value)}
-          />
-        </TextInputGroup>
-        <Button
-          isAriaDisabled={!query || !result} // Disabled during loading.
-          onClick={() => {
-            setResult(null);
-          }}
-        >
-          Query
+        <FlexItem align={{ default: 'alignRight' }}>
+          <ExpandableSectionToggle
+            contentId={queryContentID}
+            toggleId={queryToggleID}
+            isExpanded={showQuery}
+            onToggle={(on: boolean) => setShowQuery(on)}
+          >
+            {showQuery ? t('Hide Query') : t('Show Query')}
+          </ExpandableSectionToggle>
+        </FlexItem>
+      </Flex>
+      <ExpandableSection
+        contentId={queryContentID}
+        toggleId={queryToggleID}
+        isExpanded={showQuery}
+        isDetached
+        isIndented
+      >
+        <Flex direction={{ default: 'column' }}>
+          <Tooltip content={t('Korrel8 query selecting the starting points for correlation.')}>
+            <TextArea
+              className="tp-plugin__panel-query-input"
+              placeholder="domain:class:querydata"
+              id={queryInputID}
+              value={query}
+              onChange={(_event, value) => setQuery(value)}
+              resizeOrientation="vertical"
+            />
+          </Tooltip>
+          <Flex>
+            <Tooltip content={t('Show graph of connected classes up to the specified depth.')}>
+              <Radio
+                label={t('Neighbourhood depth: ')}
+                name={queryTypeOptions}
+                id="neighbourhood-option"
+                isChecked={queryType === QueryType.Neighbour}
+                onChange={(_: React.FormEvent, on: boolean) => {
+                  on && setQueryType(QueryType.Neighbour);
+                }}
+              />
+            </Tooltip>
+            <NumberInput
+              value={depth}
+              min={minDepth}
+              max={maxDepth}
+              isDisabled={queryType !== QueryType.Neighbour}
+              onPlus={() => setDepth((depth || 0) + 1)}
+              onMinus={() => (depth || 0) > minDepth && setDepth(depth - 1)}
+              onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                const n = Number((event.target as HTMLInputElement).value);
+                setDepth(isNaN(n) ? 1 : n);
+              }}
+            />
+          </Flex>
+          <Flex>
+            <Tooltip content={t('Show graph of paths to signals of the specified class.')}>
+              <Radio
+                label={t('Goal class: ')}
+                name={queryTypeOptions}
+                id="goal-option"
+                isChecked={queryType === QueryType.Goal}
+                onChange={(_: React.FormEvent, on: boolean) => on && setQueryType(QueryType.Goal)}
+              />
+            </Tooltip>
+            <FlexItem>
+              <TextInput
+                value={goal}
+                isDisabled={queryType !== QueryType.Goal}
+                placeholder="domain:class"
+                onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                  setGoal((event.target as HTMLInputElement).value);
+                }}
+              />
+            </FlexItem>
+          </Flex>
+        </Flex>
+        <Button isAriaDisabled={!query} onClick={() => runQuery()} variant="secondary">
+          {t('Query')}
         </Button>
-      </FlexItem>
+      </ExpandableSection>
+      <Divider />
       <FlexItem className="tp-plugin__panel-topology-container" grow={{ default: 'grow' }}>
         {topology(result, t)}
       </FlexItem>

--- a/web/src/components/Popover.tsx
+++ b/web/src/components/Popover.tsx
@@ -32,6 +32,7 @@ export default function Popover() {
         <Flex className="tp-plugin__popover-title-bar" gap={{ default: 'gapNone' }}>
           <FlexItem grow={{ default: 'grow' }}>
             <Title headingLevel="h1">{t('Troubleshooting')}</Title>
+            <p>{t('Find related resources.')}</p>
           </FlexItem>
           <FlexItem>
             <Button variant="plain" aria-label="Close" onClick={close}>

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -1,5 +1,5 @@
 import { cancellableFetch } from './cancellable-fetch';
-import { Korrel8rResponse, Korrel8rGraphNeighboursResponse } from './korrel8r/query.types';
+import { Korrel8rResponse, Korrel8rGraphResponse } from './korrel8r/query.types';
 
 const KORREL8R_ENDPOINT = '/api/proxy/plugin/troubleshooting-panel-console-plugin/korrel8r';
 
@@ -12,19 +12,36 @@ export const listDomains = () => {
   );
 };
 
-export const getNeighborsGraph = ({ query }: { query?: string } = {}) => {
+export const getNeighborsGraph = ({ query }: { query?: string }, depth: number) => {
   const requestData = {
     method: 'POST',
     body: JSON.stringify({
       start: {
         queries: query ? [query] : [],
       },
-      depth: 5,
+      depth: depth,
     }),
   };
 
-  return cancellableFetch<Korrel8rGraphNeighboursResponse>(
+  return cancellableFetch<Korrel8rGraphResponse>(
     `${KORREL8R_ENDPOINT}/api/v1alpha1/graphs/neighbours`,
+    requestData,
+  );
+};
+
+export const getGoalsGraph = ({ query }: { query?: string }, goal: string) => {
+  const requestData = {
+    method: 'POST',
+    body: JSON.stringify({
+      start: {
+        queries: query ? [query] : [],
+      },
+      goals: [goal],
+    }),
+  };
+
+  return cancellableFetch<Korrel8rGraphResponse>(
+    `${KORREL8R_ENDPOINT}/api/v1alpha1/graphs/goals`,
     requestData,
   );
 };

--- a/web/src/korrel8r/query.types.ts
+++ b/web/src/korrel8r/query.types.ts
@@ -27,7 +27,7 @@ export type QueryCount = {
 
 export type Korrel8rResponse = Array<QueryNode>;
 
-export type Korrel8rGraphNeighboursResponse = {
+export type Korrel8rGraphResponse = {
   nodes: Array<QueryNode>;
   edges?: Array<QueryEdge>;
 };


### PR DESCRIPTION
Add controls to:
- show/hide query details
- choose neighbour or goal search
- specify depth or goal class