### PR TITLE
OU-484: Allow the troubleshooting panel to be triggered globally from the console

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -14,5 +14,12 @@
       "scope": "tp",
       "reducer": { "$codeRef": "TPReducer" }
     }
+  },
+  {
+    "type": "console.context-provider",
+    "properties": {
+      "provider": { "$codeRef": "NullContextProvider" },
+      "useValueHook": { "$codeRef": "usePopover" }
+    }
   }
 ]

--- a/web/package.json
+++ b/web/package.json
@@ -78,7 +78,9 @@
     "description": "Troubleshooting Panel Plugin for OpenShift console. Used to display Korrel8r information",
     "exposedModules": {
       "TroubleshootingPanelActionsProvider": "./hooks/useTroubleshootingPanel",
-      "TPReducer": "./redux-reducers"
+      "TPReducer": "./redux-reducers",
+      "NullContextProvider": "./components/NullContextProvider",
+      "usePopover": "./hooks/usePopover"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/web/src/components/NullContextProvider.tsx
+++ b/web/src/components/NullContextProvider.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+const NullContext = React.createContext(null);
+
+export default NullContext.Provider;

--- a/web/src/hooks/usePopover.tsx
+++ b/web/src/hooks/usePopover.tsx
@@ -1,0 +1,22 @@
+import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import * as React from 'react';
+
+import { useSelector } from 'react-redux';
+import Popover from '../components/Popover';
+import { State } from '../redux-reducers';
+
+const usePopover = () => {
+  const isOpen = useSelector((state: State) => state.plugins?.tp?.get('isOpen'));
+
+  const launchModal = useModal();
+
+  React.useEffect(() => {
+    if (launchModal && isOpen) {
+      launchModal?.(Popover, {});
+    }
+  }, [launchModal, isOpen]);
+
+  return [];
+};
+
+export default usePopover;

--- a/web/src/hooks/useTroubleshootingPanel.tsx
+++ b/web/src/hooks/useTroubleshootingPanel.tsx
@@ -1,27 +1,18 @@
-import * as React from 'react';
-import {
-  Action,
-  ExtensionHook,
-  useActivePerspective,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { Action, ExtensionHook, useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 import { InfrastructureIcon } from '@patternfly/react-icons';
-import Popover from '../components/Popover';
-import { useBoolean } from './useBoolean';
-import { useDispatch } from 'react-redux';
-import { useKorrel8r } from './useKorrel8r';
-import { openTP } from '../redux-actions';
-import { useURLState } from './useURLState';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { openTP } from '../redux-actions';
+import { useKorrel8r } from './useKorrel8r';
+import { useURLState } from './useURLState';
 
 const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
   const { isKorrel8rReachable } = useKorrel8r();
   const { korrel8rQueryFromURL } = useURLState();
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
   const [perspective] = useActivePerspective();
-  const launchModal = useModal();
   const dispatch = useDispatch();
-  const [isLaunched, , setLaunched] = useBoolean(false);
   const open = React.useCallback(() => {
     dispatch(openTP());
   }, [dispatch]);
@@ -39,25 +30,19 @@ const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
           </div>
         ),
         description: t('Open the Troubleshooting Panel'),
-        cta: () => {
-          if (!isLaunched && launchModal) {
-            launchModal?.(Popover, {});
-            setLaunched();
-          }
-          open();
-        },
+        cta: open,
         disabled: false,
         tooltip: t('Open the Troubleshooting Panel'),
       },
     ];
     return actions;
-  }, [isLaunched, launchModal, open, setLaunched, t, isKorrel8rReachable, perspective]);
+  }, [open, t, isKorrel8rReachable, perspective]);
 
   const [actions, setActions] = React.useState<Array<Action>>(getActions());
 
   React.useEffect(() => {
     setActions(getActions());
-  }, [korrel8rQueryFromURL, isLaunched, launchModal, open, setLaunched, getActions]);
+  }, [korrel8rQueryFromURL, open, getActions]);
 
   return [actions, true, null];
 };

--- a/web/src/redux-reducers.ts
+++ b/web/src/redux-reducers.ts
@@ -14,7 +14,7 @@ export type State = {
 const reducer = (state: TPState, action: TPAction): TPState => {
   if (!state) {
     return ImmutableMap({
-      isOpen: true,
+      isOpen: false,
       query: '',
       queryResponse: {
         nodes: [],


### PR DESCRIPTION
This PR will allow the console to trigger the panel just by dispatching the `openTP` action with redux. This will allow to trigger the panel globally from the masthead menu.