### PR TITLE
fix: log and netflow query-URL conversion

### DIFF
--- a/web/src/__tests__/alert-node.spec.ts
+++ b/web/src/__tests__/alert-node.spec.ts
@@ -64,8 +64,8 @@ describe('AlertNode.fromQuery', () => {
   });
 
   it.each([
-    { query: 'alert:aler', expected: 'Invalid alert query: alert:aler' },
-    { query: 'alert:alert:', expected: 'Invalid alert query' },
+    { query: 'alert:aler', expected: 'Expected alert query: alert:aler' },
+    { query: 'alert:alert:', expected: 'Expected alert query' },
   ])('$query throws', ({ query, expected }) => {
     expect(() => AlertNode.fromQuery(query)).toThrow(expected);
   });

--- a/web/src/__tests__/k8s-node.spec.ts
+++ b/web/src/__tests__/k8s-node.spec.ts
@@ -151,8 +151,8 @@ describe('K8sNode.fromQuery', () => {
   });
 
   it.each([
-    { query: `foo:bar:baz`, err: 'Invalid k8s query' },
-    { query: `k8s:Pod`, err: 'Invalid k8s query' },
+    { query: `foo:bar:baz`, err: 'Expected k8s query' },
+    { query: `k8s:Pod`, err: 'Expected k8s query' },
     { query: `k8s:nosuch:{}`, err: 'Unknown k8s kind:' },
     { query: `k8s:Role.v1.bad.group:{}`, err: `Unknown k8s kind:` },
   ])('raises error on $query', ({ query, err }) =>

--- a/web/src/__tests__/log-node.spec.ts
+++ b/web/src/__tests__/log-node.spec.ts
@@ -1,104 +1,94 @@
 import { LogNode } from '../korrel8r/log';
 
-/**
- * Bad deployment is the suggested deployment from korrel8r to show its functionality within the
- * logging plugin. https://korrel8r.github.io/korrel8r/#troubleshooting-no-related-logs
- *
- */
-describe('Test LogNode Parsing', () => {
-  it('Test different log type urls to query parsing', () => {
-    [
-      {
-        url: 'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}|json&tenant=infrastructure',
-        expected:
-          'log:infrastructure:{kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}',
-      },
-      {
-        url: 'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}|json',
-        expected:
-          'log:infrastructure:{kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}',
-      },
-      {
-        url: 'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000"}|json&tenant=infrastructure',
-        expected:
-          'log:infrastructure:{kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}',
-      },
-    ].forEach(({ url, expected }) => {
-      expect(LogNode.fromURL(url)?.toQuery()).toEqual(expected);
-    });
+describe('LogNode.fromURL', () => {
+  it.each([
+    {
+      url: `monitoring/logs?q=${encodeURIComponent(
+        '{kubernetes_namespace_name="default",kubernetes_pod_name="foo"}',
+      )}&tenant=infrastructure`,
+      query:
+        `log:infrastructure:{kubernetes_namespace_name="default"` +
+        `,kubernetes_pod_name="foo"}|json`,
+    },
+    {
+      url: `monitoring/logs?q=${encodeURIComponent(
+        '{kubernetes_namespace_name="default",' +
+          'kubernetes_pod_name="foo",log_type="infrastructure"}',
+      )}`,
+      query:
+        `log:infrastructure:{kubernetes_namespace_name="default",` +
+        `kubernetes_pod_name="foo",log_type="infrastructure"}|json`,
+    },
+    {
+      url: `monitoring/logs?q=${encodeURIComponent(
+        '{kubernetes_namespace_name="default",kubernetes_pod_name="foo"}|json',
+      )}&tenant=infrastructure`,
+      query:
+        `log:infrastructure:{kubernetes_namespace_name="default",` +
+        `kubernetes_pod_name="foo"}|json`,
+    },
+    {
+      url: `monitoring/logs?q=${encodeURIComponent(
+        '{kubernetes_namespace_name="default",kubernetes_pod_name="foo",log_type="infrastructure"}|json',
+      )}&tenant=infrastructure`,
+      query:
+        `log:infrastructure:{kubernetes_namespace_name="default",` +
+        `kubernetes_pod_name="foo",log_type="infrastructure"}|json`,
+    },
+    {
+      url: `/k8s/ns/foo/pods/bar/aggregated-logs`,
+      query: `log:application:{kubernetes_namespace_name="foo",kubernetes_pod_name="bar"}|json`,
+    },
+    {
+      url: `/k8s/ns/kube/pods/bar/aggregated-logs`,
+      query: `log:infrastructure:{kubernetes_namespace_name="kube",kubernetes_pod_name="bar"}|json`,
+    },
+  ])('$url', ({ url, query }) => expect(LogNode.fromURL(url)?.toQuery()).toEqual(query));
+});
+
+describe('LogNode.fromQuery', () => {
+  it.each([
+    {
+      query:
+        `log:infrastructure:{kubernetes_namespace_name="default",` +
+        `kubernetes_pod_name="foo"}|json`,
+      url: `monitoring/logs?q=${encodeURIComponent(
+        '{kubernetes_namespace_name="default",kubernetes_pod_name="foo"}|json',
+      )}&tenant=infrastructure`,
+    },
+    {
+      query: 'log:infrastructure:{kubernetes_namespace_name="default",log_type="infrastructure"}',
+      url: `monitoring/logs?q=${encodeURIComponent(
+        '{kubernetes_namespace_name="default",log_type="infrastructure"}|json',
+      )}&tenant=infrastructure`,
+    },
+  ])('$query', ({ url, query }) => expect(LogNode.fromQuery(query)?.toURL()).toEqual(url));
+});
+
+describe('expected errors', () => {
+  it.each([
+    {
+      url: 'monitoring/log',
+      expected: 'Expected log URL: monitoring/log',
+    },
+    {
+      url: 'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="foo"}|json',
+      expected: 'No log class found in URL',
+    },
+  ])('error from url: $url', ({ url, expected }) => {
+    expect(() => LogNode.fromURL(url)).toThrow(expected);
   });
 
-  it('URL => Query => URL', () => {
-    const url =
-      'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}|json&tenant=infrastructure';
-    const expectedQuery =
-      'log:infrastructure:{kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}';
-    const actualQuery = LogNode.fromURL(url)?.toQuery();
-    expect(actualQuery).toEqual(expectedQuery);
-    expect(LogNode.fromQuery(expectedQuery)?.toURL()).toEqual(url);
-  });
-
-  it('Query => URL => Query', () => {
-    const query =
-      'log:infrastructure:{kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}';
-    const expectedURL =
-      'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000",log_type="infrastructure"}|json&tenant=infrastructure';
-    const actualURL = LogNode.fromQuery(query)?.toURL();
-    expect(actualURL).toEqual(expectedURL);
-    expect(LogNode.fromURL(actualURL)?.toQuery()).toEqual(query);
-  });
-
-  it('Test url to query parsing with expected errors', () => {
-    [
-      {
-        url: 'monitoring/log',
-        expected: 'Expected url to start with monitoring/logs',
-      },
-      {
-        url: 'monitoring/logs',
-        expected: 'Expected URL to contain query parameters',
-      },
-      {
-        url: 'monitoring/logs?',
-        expected: 'Expected URL to contain query parameters',
-      },
-      {
-        url: 'monitoring/logs?q={kubernetes_namespace_name="default",kubernetes_pod_name="bad-deployment-000000000-00000"}|json',
-        expected: 'Expected query to contain log class',
-      },
-      {
-        url: 'monitoring/logs?tenant=infrastructure',
-        expected: 'Expected more than 0 relevant query parameters',
-      },
-    ].forEach(({ url, expected }) => {
-      expect(() => LogNode.fromURL(url)).toThrow(expected);
-    });
-  });
-
-  it('Test query to url parsing with expected errors', () => {
-    [
-      {
-        query: 'lo',
-        expected: 'Expected query to start with log:',
-      },
-      {
-        query: 'log:',
-        expected: 'Expected query to contain class',
-      },
-      {
-        query: 'log:incorrect',
-        expected: 'Unknown log class',
-      },
-      {
-        query: 'log:infrastructure:',
-        expected: 'Expected more than 0 relevant query parameters',
-      },
-      {
-        query: 'log:infrastructure:{}',
-        expected: 'Expected more than 0 relevant query parameters',
-      },
-    ].forEach(({ query, expected }) => {
-      expect(() => LogNode.fromQuery(query)).toThrow(expected);
-    });
+  it.each([
+    {
+      query: 'foo:bar:baz',
+      expected: 'Expected log query: foo:bar:baz',
+    },
+    {
+      query: 'log:incorrect:{}',
+      expected: 'Expected log class in query',
+    },
+  ])('error from query: $query', ({ query, expected }) => {
+    expect(() => LogNode.fromQuery(query)).toThrow(expected);
   });
 });

--- a/web/src/korrel8r/alert.ts
+++ b/web/src/korrel8r/alert.ts
@@ -38,11 +38,9 @@ export class AlertNode extends Korrel8rNode {
   static fromQuery(query: string): Korrel8rNode {
     try {
       const [, data] = parseQuery(domain, query);
-      const search = new URLSearchParams();
       const selectors = keyValueList(JSON.parse(data));
-      if (selectors) search.set('alerts', selectors);
       return new AlertNode(
-        `monitoring/alerts${search.size > 0 ? '?' + search.toString() : ''}`,
+        `monitoring/alerts${selectors ? `?alerts=${encodeURIComponent(selectors)}` : ''}`,
         query,
       );
     } catch (e) {

--- a/web/src/korrel8r/metric.ts
+++ b/web/src/korrel8r/metric.ts
@@ -13,7 +13,7 @@ export class MetricNode extends Korrel8rNode {
   }
 
   static fromURL(url: string): Korrel8rNode {
-    const [_, params] = parseURL('metric', 'monitoring/query-browser', url);
+    const [, params] = parseURL('metric', 'monitoring/query-browser', url);
     if (!params || params.size == 0)
       throw new NodeError(`Expected query parameters in metric URL: ${url}`);
     const promqlQuery = params.get('query0');

--- a/web/src/korrel8r/query-url.ts
+++ b/web/src/korrel8r/query-url.ts
@@ -20,7 +20,7 @@ export const parseURL = (
 // Return the short class name and data section of the query. Throw if it doesn't match the domain.
 export const parseQuery = (domain: string, query: string): [clazz: string, data: string] => {
   const [, domain2, clazz, data] = query.match(/^([^:]+):([^:]+):(.+)$/) ?? [];
-  if (domain2 != domain) throw new NodeError(`Invalid ${domain} query: ${query}`);
+  if (domain2 != domain) throw new NodeError(`Expected ${domain} query: ${query}`);
   return [clazz, data];
 };
 


### PR DESCRIPTION
- Netflow URL format seems to have changed, there is no longer a q= parameter.
- Fixed URL encoding parameter issues.
- Updated error messages to be more consistent.
- Support pod aggregated log URLs.
- Simplify log conversions.


NOTE: already reviewed as https://github.com/openshift/troubleshooting-panel-console-plugin/pull/50
which was closed by mistake.