### PR TITLE
fix(#66): Show single node graphs.

### DIFF
--- a/web/src/components/Korrel8rPanel.tsx
+++ b/web/src/components/Korrel8rPanel.tsx
@@ -216,12 +216,12 @@ const Topology: React.FC<TopologyProps> = ({ result, t, setQuery }) => {
     return <Loading />;
   }
 
-  if (result.graph && result.graph.nodes && result.graph.edges) {
+  if (result.graph && result.graph.nodes) {
     // Non-empty graph
     return (
       <Korrel8rTopology
-        queryNodes={result.graph.nodes}
-        queryEdges={result.graph.edges}
+        queryNodes={result.graph.nodes || []}
+        queryEdges={result.graph.edges || []}
         loggingAvailable={loggingAvailable}
         netobserveAvailable={netobserveAvailable}
         setQuery={setQuery}


### PR DESCRIPTION
Previously was showing empty for a graph with a single node and  no edges.