### PR TITLE
OU-564: add query validation before trimming

### DIFF
--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -13,12 +13,11 @@ export const listDomains = () => {
 };
 
 export const getNeighborsGraph = ({ query }: { query?: string }, depth: number) => {
-  query = query.trim();
   const requestData = {
     method: 'POST',
     body: JSON.stringify({
       start: {
-        queries: query ? [query] : [],
+        queries: query ? [query.trim()] : [],
       },
       depth: depth,
     }),
@@ -31,12 +30,11 @@ export const getNeighborsGraph = ({ query }: { query?: string }, depth: number) 
 };
 
 export const getGoalsGraph = ({ query }: { query?: string }, goal: string) => {
-  query = query.trim();
   const requestData = {
     method: 'POST',
     body: JSON.stringify({
       start: {
-        queries: query ? [query] : [],
+        queries: query ? [query.trim()] : [],
       },
       goals: [goal],
     }),


### PR DESCRIPTION
This PR adds a validation before trimming a query that can be undefined. This will prevent errors when opening the panel from views in which the URL does not produce a korrel8r query