### PR TITLE
OU-537: Persist Query Information between closing and opening

### DIFF
--- a/web/src/components/topology/Korrel8rTopology.tsx
+++ b/web/src/components/topology/Korrel8rTopology.tsx
@@ -33,6 +33,7 @@ import { Korrel8rNode } from '../../korrel8r/korrel8r.types';
 import { InvalidNode } from '../../korrel8r/invalid';
 import { TFunction, useTranslation } from 'react-i18next';
 import './korrel8rtopology.css';
+import { Query, QueryType } from '../../redux-actions';
 
 interface Korrel8rTopologyNodeProps {
   element: Node;
@@ -201,7 +202,7 @@ export const Korrel8rTopology: React.FC<{
   queryEdges: Array<QueryEdge>;
   loggingAvailable: boolean;
   netobserveAvailable: boolean;
-  setQuery: (query: string) => void;
+  setQuery: (query: Query) => void;
 }> = ({ queryNodes, queryEdges, loggingAvailable, netobserveAvailable, setQuery }) => {
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
   const location = useLocation();
@@ -248,7 +249,12 @@ export const Korrel8rTopology: React.FC<{
       if (!korrel8rNode) {
         return;
       }
-      setQuery(korrel8rNode.toQuery());
+      setQuery({
+        query: korrel8rNode.toQuery(),
+        queryType: QueryType.Neighbour,
+        depth: 3,
+        goal: null,
+      });
       history.push('/' + korrel8rNode.toURL());
     },
     [history, nodes, selectedIds, setQuery],

--- a/web/src/hooks/useTroubleshootingPanel.tsx
+++ b/web/src/hooks/useTroubleshootingPanel.tsx
@@ -3,7 +3,7 @@ import { InfrastructureIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { openTP } from '../redux-actions';
+import { openTP, QueryType, setPersistedQuery } from '../redux-actions';
 import { useKorrel8r } from './useKorrel8r';
 import { useURLState } from './useURLState';
 
@@ -14,6 +14,14 @@ const useTroubleshootingPanel: ExtensionHook<Array<Action>> = () => {
   const [perspective] = useActivePerspective();
   const dispatch = useDispatch();
   const open = React.useCallback(() => {
+    dispatch(
+      setPersistedQuery({
+        query: '',
+        queryType: QueryType.Neighbour,
+        depth: 3,
+        goal: null,
+      }),
+    );
     dispatch(openTP());
   }, [dispatch]);
 

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -1,5 +1,6 @@
 import { cancellableFetch } from './cancellable-fetch';
 import { Korrel8rGraphResponse, Korrel8rResponse } from './korrel8r/query.types';
+import { Query } from './redux-actions';
 
 const KORREL8R_ENDPOINT = '/api/proxy/plugin/troubleshooting-panel-console-plugin/korrel8r';
 
@@ -12,14 +13,14 @@ export const listDomains = () => {
   );
 };
 
-export const getNeighborsGraph = ({ query }: { query?: string }, depth: number) => {
+export const getNeighborsGraph = (query: Query) => {
   const requestData = {
     method: 'POST',
     body: JSON.stringify({
       start: {
-        queries: query ? [query.trim()] : [],
+        queries: query.query ? [query.query.trim()] : [],
       },
-      depth: depth,
+      depth: query.depth,
     }),
   };
 
@@ -29,14 +30,14 @@ export const getNeighborsGraph = ({ query }: { query?: string }, depth: number) 
   );
 };
 
-export const getGoalsGraph = ({ query }: { query?: string }, goal: string) => {
+export const getGoalsGraph = (query: Query) => {
   const requestData = {
     method: 'POST',
     body: JSON.stringify({
       start: {
-        queries: query ? [query.trim()] : [],
+        queries: query.query ? [query.query.trim()] : [],
       },
-      goals: [goal],
+      goals: [query.goal],
     }),
   };
 

--- a/web/src/redux-actions.ts
+++ b/web/src/redux-actions.ts
@@ -3,14 +3,28 @@ import { action, ActionType as Action } from 'typesafe-actions';
 export enum ActionType {
   CloseTroubleshootingPanel = 'closeTroubleshootingPanel',
   OpenTroubleshootingPanel = 'openTroubleshootingPanel',
+  SetPersistedQuery = 'setPersistedQuery',
 }
+
+export enum QueryType {
+  Neighbour,
+  Goal,
+}
+export type Query = {
+  query: string;
+  queryType: QueryType;
+  depth: null | number;
+  goal: null | string;
+};
 
 export const closeTP = () => action(ActionType.CloseTroubleshootingPanel);
 export const openTP = () => action(ActionType.OpenTroubleshootingPanel);
+export const setPersistedQuery = (query: Query) => action(ActionType.SetPersistedQuery, { query });
 
 const actions = {
   closeTP,
   openTP,
+  setPersistedQuery,
 };
 
 export type TPAction = Action<typeof actions>;

--- a/web/src/redux-reducers.ts
+++ b/web/src/redux-reducers.ts
@@ -1,6 +1,6 @@
 import { Map as ImmutableMap } from 'immutable';
 
-import { ActionType, TPAction } from './redux-actions';
+import { ActionType, QueryType, TPAction } from './redux-actions';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TPState = ImmutableMap<string, any>;
@@ -15,10 +15,11 @@ const reducer = (state: TPState, action: TPAction): TPState => {
   if (!state) {
     return ImmutableMap({
       isOpen: false,
-      query: '',
-      queryResponse: {
-        nodes: [],
-        edges: [],
+      persistedQuery: {
+        query: '',
+        queryType: QueryType.Neighbour,
+        depth: 3,
+        goal: null,
       },
     });
   }
@@ -29,6 +30,9 @@ const reducer = (state: TPState, action: TPAction): TPState => {
 
     case ActionType.OpenTroubleshootingPanel:
       return state.set('isOpen', true);
+
+    case ActionType.SetPersistedQuery:
+      return state.set('persistedQuery', action.payload.query);
 
     default:
       break;


### PR DESCRIPTION
This PR looks to persist the korrel8r query information in the store to allow users to close and open the panel without losing track of where their old query was. 

Of note, because the store is reinstantiated each time a tab is opened, this won't persist the query when refreshing or opening the console at a later time. I think this is a fine tradeoff which clears away the issue of stale queries. If we want persistence through new tabs and refreshing, we will need to store in the browser storage instead.

The swap of query to an object does lead to a decent amount of spreading the old object out then overriding only one of the fields, but it feels to the point and expressive so I think its fine.