### PR TITLE
NO-JIRA: replace react-router* with react-router-dom-v5-compat

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "troubleshooting-panel-console-plugin",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "react-router-dom-v5-compat": "^6.30.0"
+      },
       "devDependencies": {
         "@cypress/webpack-preprocessor": "^5.15.5",
         "@openshift-console/dynamic-plugin-sdk": "^1.0.0",
@@ -49,8 +52,6 @@
         "react-helmet": "^6.1.0",
         "react-i18next": "^11.7.3",
         "react-redux": "7.2.2",
-        "react-router": "5.3.x",
-        "react-router-dom": "5.3.x",
         "style-loader": "^3.3.1",
         "stylelint": "^15.3.0",
         "stylelint-config-standard": "^31.0.0",
@@ -1944,7 +1945,6 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
       "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3495,10 +3495,10 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
-      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
-      "dev": true,
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -11135,7 +11135,6 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
       "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
@@ -11149,7 +11148,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -12489,8 +12487,7 @@
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -14619,8 +14616,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -15298,7 +15294,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -16756,7 +16751,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17360,7 +17354,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -18823,7 +18816,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -19119,7 +19111,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -19132,7 +19123,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19205,8 +19195,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-measure": {
       "version": "2.5.2",
@@ -19253,7 +19242,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -19273,7 +19261,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
       "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -19288,14 +19275,14 @@
       }
     },
     "node_modules/react-router-dom-v5-compat": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.23.0.tgz",
-      "integrity": "sha512-ffDaOI5UuahWs+n8qFj0S3N8L6VsUjU9RX2WMQWQPyoGRUxaBeaXjEngZDXhz5nsbyF+N5YAY21SmGC/8DlPug==",
-      "dev": true,
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
+      "integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.16.0",
+        "@remix-run/router": "1.23.0",
         "history": "^5.3.0",
-        "react-router": "6.23.0"
+        "react-router": "6.30.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -19310,18 +19297,17 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
-      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
-      "dev": true,
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.16.0"
+        "@remix-run/router": "1.23.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -19572,8 +19558,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -19975,8 +19960,7 @@
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
@@ -20176,7 +20160,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -22153,14 +22136,12 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -23302,8 +23283,7 @@
     "node_modules/value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/value-or-function": {
       "version": "3.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -60,8 +60,6 @@
     "react-helmet": "^6.1.0",
     "react-i18next": "^11.7.3",
     "react-redux": "7.2.2",
-    "react-router": "5.3.x",
-    "react-router-dom": "5.3.x",
     "style-loader": "^3.3.1",
     "stylelint": "^15.3.0",
     "stylelint-config-standard": "^31.0.0",
@@ -87,5 +85,8 @@
     "dependencies": {
       "@console/pluginAPI": "*"
     }
+  },
+  "dependencies": {
+    "react-router-dom-v5-compat": "^6.30.0"
   }
 }

--- a/web/src/components/topology/Korrel8rTopology.tsx
+++ b/web/src/components/topology/Korrel8rTopology.tsx
@@ -26,7 +26,7 @@ import {
 } from '@patternfly/react-topology';
 import * as React from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
-import { useHistory, useLocation } from 'react-router';
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { nodeToLabel } from '../../korrel8r-utils';
 import { InvalidNode } from '../../korrel8r/invalid';
 import { Korrel8rNode } from '../../korrel8r/korrel8r.types';
@@ -213,7 +213,7 @@ export const Korrel8rTopology: React.FC<{
 }> = ({ queryNodes, queryEdges, loggingAvailable, netobserveAvailable, setQuery }) => {
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const persistedQuery = useSelector((state: State) => {
     return state.plugins?.tp?.get('persistedQuery');
   }) as Query;
@@ -273,9 +273,9 @@ export const Korrel8rTopology: React.FC<{
         goal: null,
         constraint: persistedQuery.constraint,
       });
-      history.push('/' + korrel8rNode.toURL());
+      navigate('/' + korrel8rNode.toURL());
     },
-    [history, nodes, selectedIds, setQuery, persistedQuery],
+    [navigate, nodes, selectedIds, setQuery, persistedQuery],
   );
 
   const controller = React.useMemo(() => {

--- a/web/src/hooks/useQueryParams.ts
+++ b/web/src/hooks/useQueryParams.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 export const useQueryParams = () => {
   const location = useLocation();

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useQueryParams } from './useQueryParams';
 import { Korrel8rNodeFactory } from '../korrel8r/node-factory';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 export type QueryParams = [string, string][];
 


### PR DESCRIPTION
### Context
remove react-router and react-router-dom to be replaced by react-router-dom-compat-v5 for transition to react-router v6

### Related JIRA from /openshift/console changes
https://github.com/openshift/console/pull/14957

### Threads
Slack #observability-ui-interal thread
https://redhat-internal.slack.com/archives/C03EPFR2BAR/p1744392852882399

Slack #announce-console-plugins
https://redhat-internal.slack.com/archives/C032NLNEE8G/p1744391666020899