### PR TITLE
NO-JIRA: add incluster development of UI plugin using devspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ web/dist/
 web/node_modules/
 web/coverage/
 yarn-error.log
+
+# Ignore DevSpace cache and log folder
+.devspace/

--- a/Dockerfile.devspace
+++ b/Dockerfile.devspace
@@ -1,0 +1,26 @@
+FROM registry.redhat.io/ubi9/go-toolset:latest AS go-builder
+
+WORKDIR /opt/app-root
+
+USER 0
+RUN chgrp -R 0 /opt/app-root
+RUN chmod -R g+rw /opt/app-root
+
+RUN mkdir /.devspace
+RUN chgrp -R 0 /.devspace
+RUN chmod -R g+rw /.devspace
+
+ENV HUSKY=0
+
+COPY Makefile Makefile
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN make install-backend
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN make build-backend
+
+ENTRYPOINT ["make", "start-devspace-backend"]

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ deploy:	test-frontend		## Build and push image, reinstall on cluster using helm.
 	PUSH=1 scripts/build-image.sh
 	helm install troubleshooting-panel-console-plugin charts/openshift-console-plugin -n troubleshooting-panel-console-plugin --create-namespace --set plugin.image=$(IMAGE)
 
+.PHONY: start-devspace-backend
+start-devspace-backend:
+	/opt/app-root/plugin-backend -port=9443 -cert=/var/serving-cert/tls.crt -key=/var/serving-cert/tls.key -plugin-config-path=/etc/plugin/config.yaml -static-path=/opt/app-root/web/dist -config-path=/opt/app-root/web/dist
+
 ## Code generation
 gen-client: web/src/korrel8r/client
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,22 @@ best practice is to prefix your CSS classnames with your plugin name to avoid
 conflicts. Please don't disable these rules without understanding how they can
 break console styles!
 
+### Running using Devspace
+
+Install the [devspace](https://www.devspace.sh/docs/getting-started/installation) cli.
+
+1. Install the frontend dependencies running `make install-frontend`.
+2. Start the frontend `make start-frontend`.
+3. Deploy the troubleshooting panel using COO/ObO.
+4. Select the namespace you want to deploy in using `devspace use namespace {NAMESPACE}`, make sure to set the namespace where the plugin has been deployed.
+5. In a different terminal start the devspace sync `devspace dev`.
+
+When running the `devspace dev` command, the pipeline will run the `scale_down_coo` function to prevent COO from fighting over control of the pod. After COO has been scaled down, devspace will "take over" the troubleshooting-panel-console-plugin pod, grabbing all of the certificates and backend binary and configuration to run in the devspace pod.
+
+After the pod has been "taken over" Devspace begins a sync process which will mirror changes from you local `./web/dist` folder into the `/opt/app-root/web/dist` folder in the devspace pod. You can then make changes to your frontend files locally which will trigger the locally running webpack dev server to rebuild the `./web/dist` folder, which will trigger Devspace to re-synced. You can then reload your console webpage to see your local changes running in the cluster.
+
+After development you can run `devspace purge` to cleanup and then call the `scale_up_coo` pipeline.
+
 ### Local Development Troubleshooting
 1. Disable cache. Select 'disable cache' in your browser's DevTools > Network > 'disable cache'. Or use private/incognito mode in your browser.
 2. Enable higher log verbosity by setting `-log-level=trace` when starting the plugin backend. For more options to set log level see [logrus documentation](https://github.com/sirupsen/logrus?tab=readme-ov-file#level-logging).

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,0 +1,38 @@
+version: v2beta1
+name: troubleshooting-panel-console-plugin
+
+functions:
+  scale_down_coo: |-
+    kubectl scale --replicas=0 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
+  scale_up_coo: |-
+    kubectl scale --replicas=1 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
+# This is a list of `pipelines` that DevSpace can execute (you can define your own)
+pipelines:
+  # This is the pipeline for the main command: `devspace dev` (or `devspace run-pipeline dev`)
+  dev:
+    run: |-
+      scale_down_coo               # 3. Scale down COO so it doesn't fight over the troubleshooting-panel
+      start_dev app                # 5. Start dev mode "app" (see "dev" section)
+  purge:
+    run: |-
+      stop_dev --all
+      scale_up_coo
+
+# This is a list of `dev` containers that are based on the containers created by your deployments
+dev:
+  app:
+    # Search for the container that runs this image
+    labelSelector:
+      # Use the instance selector that COO adds
+      app.kubernetes.io/instance: troubleshooting-panel
+    # Replace the container image with this dev-optimized image (allows to skip image building during development)
+    devImage: quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:devspace
+    # Sync files between the local filesystem and the development container
+    sync:
+      - path: ./web/dist:/opt/app-root/web/dist
+        startContainer: true
+    command: ["make"]
+    args: ["start-devspace-backend"]
+    # Inject a lightweight SSH server into the container (so your IDE can connect to the remote dev env)
+    ssh:
+      enabled: true

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set +e  # Continue on errors
+
+export NODE_ENV=development
+npm install
+
+COLOR_BLUE="\033[0;94m"
+COLOR_GREEN="\033[0;92m"
+COLOR_RESET="\033[0m"
+
+# Print useful output for user
+echo -e "${COLOR_BLUE}
+     %########%
+     %###########%       ____                 _____
+         %#########%    |  _ \   ___ __   __ / ___/  ____    ____   ____ ___
+         %#########%    | | | | / _ \\\\\ \ / / \___ \ |  _ \  / _  | / __// _ \\
+     %#############%    | |_| |(  __/ \ V /  ____) )| |_) )( (_| |( (__(  __/
+     %#############%    |____/  \___|  \_/   \____/ |  __/  \__,_| \___\\\\\___|
+ %###############%                                  |_|
+ %###########%${COLOR_RESET}
+Welcome to your development container!
+This is how you can work with it:
+- Files will be synchronized between your local machine and this container
+- Some ports will be forwarded, so you can access this container via localhost
+- Run \`${COLOR_GREEN}npm start${COLOR_RESET}\` to start the application
+"
+
+# Set terminal prompt
+export PS1="\[${COLOR_BLUE}\]devspace\[${COLOR_RESET}\] ./\W \[${COLOR_BLUE}\]\\$\[${COLOR_RESET}\] "
+if [ -z "$BASH" ]; then export PS1="$ "; fi
+
+# Include project's bin/ folder in PATH
+export PATH="./bin:$PATH"
+
+# Open shell
+bash --norc


### PR DESCRIPTION
This PR looks to add in-cluster development of plugins using [devspace](https://www.devspace.sh/). It will take over an existing troubleshooting panel deployment from COO and copy the changes that the webpack dev server makes on your local machine up into the cluster. This prevents having to run korrel8r and other plugins locally and should simplify development.

https://github.com/user-attachments/assets/9bae9808-86f4-47d5-a223-0f7ec9748469

