### PR TITLE
NO-JIRA: add unit test containerfile

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/nodejs-18:latest
+
+WORKDIR /usr/src/app
+
+RUN mkdir web
+
+COPY Makefile Makefile
+COPY web/package*.json ./web
+RUN make install-frontend-ci-clean
+
+COPY web/ /usr/src/app/web
+
+RUN make build-frontend
+
+ENTRYPOINT ["make", "test-frontend"]


### PR DESCRIPTION
This PR looks to add a containerfile which will run the cypress unit tests. Once this file has been added the prow config can be update to build and run it