### PR TITLE
OU-771: close tp in non-admin perspectives

### DIFF
--- a/web/src/components/Popover.tsx
+++ b/web/src/components/Popover.tsx
@@ -7,9 +7,11 @@ import { TimesCircleIcon } from '@patternfly/react-icons';
 import { State } from '../redux-reducers';
 import { closeTP } from '../redux-actions';
 import { useTranslation } from 'react-i18next';
+import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 
 export default function Popover() {
   const dispatch = useDispatch();
+  const [activePerspective] = useActivePerspective();
   const { t } = useTranslation('plugin__troubleshooting-panel-console-plugin');
 
   const isOpen = useSelector((state: State) => state.plugins?.tp?.get('isOpen'));
@@ -17,6 +19,12 @@ export default function Popover() {
   const close = React.useCallback(() => {
     dispatch(closeTP());
   }, [dispatch]);
+
+  React.useEffect(() => {
+    if (activePerspective !== 'admin' && isOpen) {
+      close();
+    }
+  }, [activePerspective, isOpen, close]);
 
   if (!isOpen) {
     return null;


### PR DESCRIPTION
This PR looks to close the troubleshooting panel when swapping to a non-admin perspective, as well as prevent its opening in the first place.

https://github.com/user-attachments/assets/ac68ec3c-d72b-4d3a-9142-ca5e4ba03518


