### PR TITLE
NO-JIRA: feat: add agent-navigation feature gate to uiplugin + fix reconnect

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -36,7 +36,8 @@ type Config struct {
 }
 
 type PluginConfig struct {
-	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Timeout         time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	EnableAgentNavigation bool          `json:"enableAgentNavigation,omitempty" yaml:"enableAgentNavigation,omitempty"`
 }
 
 func (pluginConfig *PluginConfig) MarshalJSON() ([]byte, error) {
@@ -52,6 +53,12 @@ func (pluginConfig *PluginConfig) MarshalJSON() ([]byte, error) {
 
 func Start(cfg *Config) {
 	router, pluginConfig := setupRoutes(cfg)
+	if pluginConfig != nil && pluginConfig.EnableAgentNavigation {
+		if cfg.Features == nil {
+			cfg.Features = make(map[string]bool)
+		}
+		cfg.Features["agent-navigation"] = true
+	}
 	router.Use(corsHeaderMiddleware())
 
 	tlsConfig := oscrypto.SecureTLSConfig(&tls.Config{})

--- a/web/src/components/AgentMenu.tsx
+++ b/web/src/components/AgentMenu.tsx
@@ -2,8 +2,6 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
-  Flex,
-  FlexItem,
   Icon,
   Label,
   MenuToggle,
@@ -25,7 +23,8 @@ const AgentMenu = () => {
 
   const agentEnabled: boolean = useSelector((s: State) => s.plugins?.tp?.get('agentEnabled'));
   const agentError: string = useSelector((s: State) => s.plugins?.tp?.get('agentError'));
-  const status = agentError ? 'warning' : undefined;
+
+  const status = !agentEnabled ? undefined : agentError ? 'danger' : 'success';
 
   useEffect(() => {
     if (agentError) {
@@ -33,6 +32,7 @@ const AgentMenu = () => {
       console.error('Agent navigation error:', agentError);
     }
   }, [agentError]);
+
   return (
     <Dropdown
       isOpen={isOpen}
@@ -40,13 +40,14 @@ const AgentMenu = () => {
       popperProps={{ position: 'end' }}
       toggle={(toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
+          status={status}
           ref={toggleRef}
           variant="plain"
           onClick={() => setIsOpen(!isOpen)}
           isExpanded={isOpen}
           aria-label={t('AI Agent settings')}
         >
-          <Icon status={status}>
+          <Icon status={status} size={'xl'}>
             <AIExperienceIcon />
           </Icon>
         </MenuToggle>
@@ -54,24 +55,26 @@ const AgentMenu = () => {
     >
       <DropdownList>
         <DropdownItem key="header">
-          <Flex alignItems={{ default: 'alignItemsCenter' }}>
-            <FlexItem grow={{ default: 'grow' }}>
-              <Switch
-                id="agent-enabled"
-                isChecked={agentEnabled}
-                hasCheckIcon
-                label={t('Agent Navigation')}
-                onChange={(_event, checked: boolean) => dispatch(setAgentEnabled(checked))}
-              />
-              <HelpPopover>
-                {t(
-                  'Allow an AI agent with your user-id to connect with this console and use it to show you relevant views and correlation searches.',
-                )}
-              </HelpPopover>
-              {!!agentError && <Label status={status}>{t('Connection error')}</Label>}
-            </FlexItem>
-          </Flex>
+          <Switch
+            id="agent-enabled"
+            isChecked={agentEnabled}
+            hasCheckIcon
+            label={t('Agent Navigation')}
+            onChange={(_event, checked: boolean) => dispatch(setAgentEnabled(checked))}
+          />
+          <HelpPopover>
+            {t(
+              'Allow an AI agent with your user-id to connect with this console and use it to show you relevant views and correlation searches.',
+            )}
+          </HelpPopover>
         </DropdownItem>
+        {!!agentError && (
+          <DropdownItem>
+            <Label status={status}>
+              {t('Connection error')}: {agentError}
+            </Label>
+          </DropdownItem>
+        )}
       </DropdownList>
     </Dropdown>
   );

--- a/web/src/components/Popover.tsx
+++ b/web/src/components/Popover.tsx
@@ -1,15 +1,15 @@
 import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, Flex, FlexItem, Stack, StackItem, Title } from '@patternfly/react-core';
 import { TimesCircleIcon } from '@patternfly/react-icons';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { closeTP } from '../redux-actions';
 import { State } from '../redux-reducers';
 import { HelpPopover } from './HelpPopover';
 import Korrel8rPanel from './Korrel8rPanel';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './popover.css';
-import { useCallback, useEffect } from 'react';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/web/src/components/topology/status.ts
+++ b/web/src/components/topology/status.ts
@@ -17,7 +17,8 @@ export const statusName = (s: Status): StatusName => {
 };
 
 // Convert Status enum to NodeStatus
-export const statusForNode = (s: Status): NodeStatus | undefined => {
+export const statusForNode = (s: Status | undefined): NodeStatus | undefined => {
+  if (s === undefined) return undefined;
   const name = statusName(s);
   return name ? NodeStatus[name] : undefined;
 };
@@ -38,10 +39,10 @@ export const mergeStatusCounts = (
   const m = new Map<string, number>(); // Original status string, total count.
   let s = 0;
   node.queries.forEach((qc) =>
-    qc.statuses.forEach((sc) => {
+    (qc.statuses ?? []).forEach((sc) => {
       if (!sc.status) return;
-      m.set(sc.status, (m.get(sc.status) ?? 0) + sc.count);
-      s = Math.max(s, toStatus(sc.status));
+      m.set(sc.status, (m.get(sc.status) ?? 0) + (sc.count ?? 0));
+      s = Math.max(s, toStatus(sc.status) ?? 0);
     }),
   );
   const sc = [...m.entries()].map(([status, count]) => ({ status, count }));

--- a/web/src/hooks/useAgentNavigation.ts
+++ b/web/src/hooks/useAgentNavigation.ts
@@ -17,8 +17,8 @@ import { useLocationQuery } from './useLocationQuery';
 import { useNavigateToQuery } from './useNavigateToQuery';
 
 const useAgentNavigation = ({
-  minDelay = 3000,
-  maxDelay = 30000,
+  minDelay = 500,
+  maxDelay = 5000,
 }: { minDelay?: number; maxDelay?: number } = {}) => {
   const agentEnabled: boolean = useSelector((s: State) => s.plugins?.tp?.get('agentEnabled'));
   const view = useLocationQuery()?.toString();
@@ -32,61 +32,76 @@ const useAgentNavigation = ({
     navigateToQueryRef.current = navigateToQuery;
   });
 
-  // Handle console update events via an SSE request.
+  // Set on connection to trigger an initial send of current state.
+  const [needSend, setNeedSend] = React.useState(false);
+
+  // Handle console update events via an SSE stream.
+  // Endless loop to stay constantly connected to the agent.
   React.useEffect(() => {
     if (!agentEnabled) {
       dispatch(setAgentError(''));
       return;
     }
+
     const controller = new AbortController();
     const consumeStream = async () => {
-      try {
-        // NOTE the generated client has reconnect and back-off built-in so
-        // we don't have to handle it here. By default it will retry until aborted.
-        const result = await getConsoleUpdates(controller.signal, { minDelay, maxDelay });
-        for await (const event of result.stream) {
-          if (controller.signal.aborted) return;
+      while (!controller.signal.aborted) {
+        try {
+          const result = await getConsoleUpdates(controller.signal, {
+            minDelay,
+            maxDelay,
+            onSseError: (err: unknown) => {
+              if (!controller.signal.aborted) {
+                dispatch(setAgentError((err as Error)?.message || String(err)));
+              }
+            },
+          });
           dispatch(setAgentError(''));
-          if (event.view) {
-            navigateToQueryRef.current(Query.parse(event.view), null);
-          }
-          if (event.search) {
-            const s = fromAPISearch(event.search);
-            if (s) {
-              dispatch(setSearch(s));
-              dispatch(openTP());
+          setNeedSend(true);
+          for await (const event of result.stream) {
+            if (controller.signal.aborted) return;
+            if (event.view) {
+              navigateToQueryRef.current(Query.parse(event.view), null);
+            }
+            if (event.search) {
+              const s = fromAPISearch(event.search);
+              if (s) {
+                dispatch(setSearch(s));
+                dispatch(openTP());
+              }
             }
           }
+        } catch (err) {
+          if (controller.signal.aborted) return;
+          dispatch(setAgentError((err as Error)?.message || String(err)));
         }
-      } catch (err) {
-        if (controller.signal.aborted) return;
-        dispatch(setAgentError(err?.message || String(err)));
+        setNeedSend(false);
+        await sleep(minDelay, controller.signal);
       }
     };
     consumeStream();
     return () => controller.abort();
   }, [agentEnabled, minDelay, maxDelay, dispatch]);
 
-  // Send console updates when view or search changes.
+  // Send console updates when local view or search changes, or on connect.
+  // Sends even when view/search are empty to signal that the console is connected.
   React.useEffect(() => {
-    if (!agentEnabled) return;
-    const body = {
-      view,
-      search: isOpen ? toAPISearch(search) : undefined,
-    };
-    if (!body.view && !body.search) return;
-
+    if (!agentEnabled || !needSend) return;
     const controller = new AbortController();
     const sendWithRetry = async () => {
       let backoff = minDelay;
       while (!controller.signal.aborted) {
         try {
-          await sendConsoleUpdate(body, controller.signal);
+          await sendConsoleUpdate(
+            { view, search: isOpen ? toAPISearch(search) : undefined },
+            controller.signal,
+          );
+          if (controller.signal.aborted) return;
           dispatch(setAgentError(''));
           return;
         } catch (err) {
           if (controller.signal.aborted) return;
-          dispatch(setAgentError(err?.message || String(err)));
+          dispatch(setAgentError((err as Error)?.message || String(err)));
           await sleep(backoff, controller.signal);
           backoff = Math.min(backoff * 2, maxDelay);
         }
@@ -94,7 +109,7 @@ const useAgentNavigation = ({
     };
     sendWithRetry();
     return () => controller.abort();
-  }, [view, search, isOpen, agentEnabled, minDelay, maxDelay, dispatch]);
+  }, [view, search, isOpen, agentEnabled, needSend, minDelay, maxDelay, dispatch]);
 };
 
 export default useAgentNavigation;
@@ -113,15 +128,15 @@ export const toAPISearch = (search: Search): api.Search | undefined => {
 };
 
 export const fromAPISearch = (search: api.Search): Search | undefined => {
-  let result: Search | undefined = undefined;
-  if (search.goals && !search.neighbors) {
+  if (search.goals && search.neighbors) return undefined; // Invalid to  set both
+  let result: Search | undefined;
+  if (search.goals) {
     result = {
       queryStr: search.goals.start?.queries?.[0],
       searchType: SearchType.Goal,
       goal: search.goals.goals?.[0],
     };
-  }
-  if (search.neighbors && !search.goals) {
+  } else if (search.neighbors) {
     result = {
       queryStr: search.neighbors.start?.queries?.[0],
       searchType: SearchType.Depth,

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -44,14 +44,19 @@ export const sendConsoleUpdate = (body: Console, signal: AbortSignal) => {
 
 export const getConsoleUpdates = (
   signal: AbortSignal,
-  { minDelay, maxDelay }: { minDelay: number; maxDelay: number },
+  {
+    minDelay,
+    maxDelay,
+    onSseError,
+  }: { minDelay: number; maxDelay: number; onSseError?: (error: unknown) => void },
 ) => {
-  // Cast: sseSleepFn is supported by the SSE runtime but not exposed in the generated Options type.
+  // Cast: SSE options are supported by the runtime but not exposed in the generated Options type.
   return consoleEvents({
     client: korrel8rClient({ signal }),
     sseDefaultRetryDelay: minDelay,
     sseMaxRetryDelay: maxDelay,
     sseSleepFn: (ms: number) => sleep(ms, signal),
+    onSseError,
   } as Parameters<typeof consoleEvents>[0]);
 };
 

--- a/web/src/korrel8r/types.ts
+++ b/web/src/korrel8r/types.ts
@@ -219,7 +219,7 @@ export class Domains {
         continue;
       }
     }
-    throw new TypeError(`cannot convert link: ${link}`);
+    throw new TypeError(`no domain recognizes link: ${link}`);
   }
 
   // Convert a korrel8r query to a relative URI Reference, try all available domains.
@@ -293,10 +293,10 @@ export class QueryCount {
     try {
       this.count = qc.count;
       this.query = Query.parse(qc.query);
-      this.statuses = qc.statuses ?? [];
     } catch (e) {
       this.error = e;
     }
+    this.statuses = qc.statuses ?? [];
   }
 
   /** Highest count first, errors last */

--- a/web/src/redux-reducers.ts
+++ b/web/src/redux-reducers.ts
@@ -18,8 +18,8 @@ const reducer = (state: TPState, action: TPAction): TPState => {
     return ImmutableMap({
       isOpen: false,
       search: defaultSearch,
-      agentEnabled: false, // True if the user switches on the agent feature.
-      agentError: '', // Error message of last unresolved error, cleared on success.
+      agentEnabled: false,
+      agentError: '',
     });
   }
 


### PR DESCRIPTION
server.go adds EnableAgentNavigation to the plugin configuration.
See the corresponding PR in observability-operator.

The rest of this commit is fixes to reconnect between panel and korrel8r,
required for it to function reliably.

DRAFT: Not tested but wanted others to see the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent-navigation can be enabled via configuration and is now reported by the UI.

* **Bug Fixes / Improvements**
  * Clearer agent connection status and explicit error messages shown in the menu.
  * More robust agent navigation connection and reconnection logic with improved update delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->