### PR TITLE
fix: COO-1841: prevent Error object from rendering as React child in AgentMenu

### DIFF
--- a/web/src/components/AdvancedSearchForm.tsx
+++ b/web/src/components/AdvancedSearchForm.tsx
@@ -161,7 +161,7 @@ export const AdvancedSearchForm: FC<AdvancedSearchFormProps> = ({ search, onSear
           <FormHelperText>
             <HelperText>
               <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
-                <p>{queryError.message}</p>
+                <p>{String(queryError.message)}</p>
               </HelperTextItem>
             </HelperText>
           </FormHelperText>
@@ -235,7 +235,7 @@ export const AdvancedSearchForm: FC<AdvancedSearchFormProps> = ({ search, onSear
                 <FormHelperText>
                   <HelperText>
                     <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
-                      {classError.message}
+                      {String(classError.message)}
                     </HelperTextItem>
                   </HelperText>
                 </FormHelperText>

--- a/web/src/components/AgentMenu.tsx
+++ b/web/src/components/AgentMenu.tsx
@@ -71,7 +71,7 @@ const AgentMenu = () => {
         {!!agentError && (
           <DropdownItem>
             <Label status={status}>
-              {t('Connection error')}: {agentError}
+              {t('Connection error')}: {String(agentError)}
             </Label>
           </DropdownItem>
         )}

--- a/web/src/components/Korrel8rPanel.tsx
+++ b/web/src/components/Korrel8rPanel.tsx
@@ -249,7 +249,7 @@ const Topology: FC<TopologyProps> = ({ isLoading, result, constraint, error, isC
 
   if (error) {
     const titleText = error?.message ? t('Search Error') : t('Search Failed');
-    const text = error?.message || error?.name || t('Unknown Error');
+    const text = String(error?.message || error?.name || t('Unknown Error'));
 
     return (
       <TopologyInfoState

--- a/web/src/components/topology/Korrel8rTopology.tsx
+++ b/web/src/components/topology/Korrel8rTopology.tsx
@@ -147,7 +147,7 @@ const Korrel8rTopologyNode: FC<
   if (node.disabled) {
     return (
       <g className="tp-plugin__topology_node--disabled">
-        <title>{node.disabled}</title>
+        <title>{String(node.disabled)}</title>
         {topologyNode}
       </g>
     );


### PR DESCRIPTION
The agentError Redux state is typed as ImmutableMap<string, any>, so
despite the TypeScript annotation, an Error object can reach the JSX
at runtime. Wrap the rendered value in String() to guarantee a valid
React child.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent menu now consistently shows connection error text so messages render reliably.
  * Panel/topology error displays updated to present error information as readable text, improving clarity when a panel or topology fails.
  * Advanced search now shows validation error messages consistently as readable text.
  * Topology node tooltips/labels now render disabled state reliably as text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->