### PR TITLE
NO-JIRA: add warning about self signed certs connection

### DIFF
--- a/doc/agent-navigation.md
+++ b/doc/agent-navigation.md
@@ -74,6 +74,10 @@ Korrel8r serves MCP at the `/mcp` endpoint (streamable HTTP). Configure your age
 > The bearer token and the console login must belong to the same user.
 > Korrel8r isolates sessions by user, so only an agent with a valid token for your user-id can access your console.
 
+> [!WARNING]
+> If you are connected to a cluster with a self-signed certificates you may need to override your mcp configuration
+> locally to prevent denying usage of self-signed certificates. For claude code you can run `export NODE_TLS_REJECT_UNAUTHORIZED=0`. This is not recommended for production use
+
 ## Enable with the AI button
 
 The troubleshooting panel has an "AI" menu with a switch to allow or disallow agent navigation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance warning that clusters with self-signed TLS certificates may require locally overriding the agent’s TLS/MCP configuration to connect. Includes a troubleshooting workaround (e.g., setting NODE_TLS_REJECT_UNAUTHORIZED=0) and a clear caution that this approach is unsafe for production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->