### PR TITLE
NO-JIRA: feat: show rule name on hover for graph edge

### DIFF
--- a/web/src/components/topology/Korrel8rTopology.tsx
+++ b/web/src/components/topology/Korrel8rTopology.tsx
@@ -13,6 +13,8 @@ import {
   DefaultEdge,
   DefaultGroup,
   DefaultNode,
+  Edge,
+  EdgeModel,
   EdgeStyle,
   ElementModel,
   getDefaultShapeDecoratorCenter,
@@ -187,6 +189,19 @@ const Korrel8rTopologyNode: FC<
   return topologyNode;
 };
 
+const Korrel8rEdge: FC<{ element: Edge<EdgeModel, { rules: korrel8r.Rule[] }> }> = ({
+  element,
+  ...rest
+}) => {
+  const rules = element.getData()?.rules ?? [];
+  const ruleNames = rules.map((r) => r.name).join('\n');
+  return (
+    <DefaultEdge element={element} {...rest}>
+      {ruleNames && <title>{ruleNames}</title>}
+    </DefaultEdge>
+  );
+};
+
 const NODE_SHAPE = NodeShape.ellipse;
 const NODE_DIAMETER = 75;
 const PADDING = 30;
@@ -246,6 +261,7 @@ export const Korrel8rTopology: FC<{
           source: edge.start.id,
           target: edge.goal.id,
           edgeStyle: EdgeStyle.default,
+          data: { rules: edge.rules },
         };
       }),
     [graph],
@@ -314,7 +330,7 @@ export const Korrel8rTopology: FC<{
         case ModelKind.node:
           return withDragNode()(withContextMenu(nodeMenu)(withSelection()(Korrel8rTopologyNode)));
         case ModelKind.edge:
-          return DefaultEdge;
+          return Korrel8rEdge;
         default:
           return undefined;
       }

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -30,12 +30,18 @@ export const listDomains = (signal: AbortSignal) => {
   return clientListDomains({ client: korrel8rClient({ signal }) });
 };
 
+const graphQuery = { options: { rules: true } };
+
 const getNeighborsGraph = (neighbours: Neighbors, signal: AbortSignal) => {
-  return graphNeighbors({ client: korrel8rClient({ signal }), body: neighbours });
+  return graphNeighbors({
+    client: korrel8rClient({ signal }),
+    body: neighbours,
+    query: graphQuery,
+  });
 };
 
 const getGoalsGraph = (goals: Goals, signal: AbortSignal) => {
-  return graphGoals({ client: korrel8rClient({ signal }), body: goals });
+  return graphGoals({ client: korrel8rClient({ signal }), body: goals, query: graphQuery });
 };
 
 export const sendConsoleUpdate = (body: Console, signal: AbortSignal) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topology edges now show associated rule names in hover text when rule data is available.
  * Neighbor and goal graph views now include rule information.
  * Correlation flow now automatically derives and uses the current start node for the topology view.
* **Bug Fixes**
  * Improved empty-state messaging when no correlated signals are found.
* **Chores**
  * Updated UI wording and formatting from **Focus** to **Correlate**, including related locale strings and user-facing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->