### PR TITLE
NO-JIRA: return to simpler retry logic

### DIFF
--- a/web/src/hooks/useAgentNavigation.ts
+++ b/web/src/hooks/useAgentNavigation.ts
@@ -19,6 +19,8 @@ import { useDomains } from './useDomains';
 import { useLocationQuery } from './useLocationQuery';
 import { useNavigateToQuery } from './useNavigateToQuery';
 
+const errorMessage = (err: unknown): string => (err as Error)?.message || String(err);
+
 const useAgentNavigation = ({
   minDelay = 500,
   maxDelay = 10000,
@@ -91,9 +93,9 @@ const useAgentNavigation = ({
         if (controller.signal.aborted) return;
         dispatch(setAgentConnected(false));
         if (lastError) {
-          dispatch(setAgentError((lastError as Error)?.message || String(lastError)));
+          dispatch(setAgentError(errorMessage(lastError)));
         }
-        await sleep(retryDelay(lastError, backoff, maxDelay), controller.signal);
+        await sleep(retryDelay(lastError, backoff), controller.signal);
         backoff = Math.min(backoff * 2, maxDelay);
       }
     };
@@ -120,8 +122,8 @@ const useAgentNavigation = ({
           return;
         } catch (err) {
           if (controller.signal.aborted) return;
-          dispatch(setAgentError((err as Error)?.message || String(err)));
-          await sleep(retryDelay(err, backoff, maxDelay), controller.signal);
+          dispatch(setAgentError(errorMessage(err)));
+          await sleep(retryDelay(err, backoff), controller.signal);
           backoff = Math.min(backoff * 2, maxDelay);
         }
       }

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -23,17 +23,8 @@ const parseRetryAfter = (value: string | null): number | undefined => {
   return undefined;
 };
 
-const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-
-// If err is a HTTP error with a Retry-After header, return that delay.
-// Otherwise return the current backoff delay.
-export const retryDelay = (err: unknown, backoff: number, maxDelay: number): number => {
-  if (err instanceof HttpError) {
-    if (err.retryAfter !== undefined) return err.retryAfter;
-    if (!RETRYABLE_STATUS_CODES.has(err.status)) return maxDelay;
-  }
-  return backoff;
-};
+export const retryDelay = (err: unknown, backoff: number): number =>
+  err instanceof HttpError && err.retryAfter !== undefined ? err.retryAfter : backoff;
 
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import {


### PR DESCRIPTION
Don't distinguish retryable/non-retryable errors, too fragile.
Backoff will ensure we don't soak the network if we get stuck on an impossible retry.
Also add explicit error text for "busy console" condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging by consistently deriving readable error text from thrown values.
  * Enhanced retry behavior by honoring server-provided retry timing when available.
  * Simplified retry-delay logic for more consistent recovery from temporary failures.
* **Refactor**
  * Centralized error-to-message extraction and reused it across streaming consumption and retry flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->