### PR TITLE
NO-JIRA: fix: don't scale COO in devspace.yaml

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,22 +1,13 @@
 version: v2beta1
 name: troubleshooting-panel-console-plugin
 
-functions:
-  scale_down_coo: |-
-    kubectl scale --replicas=0 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
-  scale_up_coo: |-
-    kubectl scale --replicas=1 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
 # This is a list of `pipelines` that DevSpace can execute (you can define your own)
 pipelines:
   # This is the pipeline for the main command: `devspace dev` (or `devspace run-pipeline dev`)
   dev:
-    run: |-
-      scale_down_coo               # 3. Scale down COO so it doesn't fight over the troubleshooting-panel
-      start_dev app                # 5. Start dev mode "app" (see "dev" section)
+    run: start_dev app # 5. Start dev mode "app" (see "dev" section)
   purge:
-    run: |-
-      stop_dev --all
-      scale_up_coo
+    run: stop_dev --all
 
 # This is a list of `dev` containers that are based on the containers created by your deployments
 dev:
@@ -30,10 +21,16 @@ dev:
     # Sync files between the local filesystem and the development container
     sync:
       - path: ./web/dist:/opt/app-root/web/dist
-        startContainer: true
         printLogs: true
+        startContainer: true
+        waitInitialSync: true
+        excludePaths:
+          - "**/*.map"
+          - "**/node_modules_patternfly*"
+        onUpload:
+          restartContainer: true
     command: ["make"]
-    args: ["start-devspace-backend", "-FEATURES=agent-navigation"]
+    args: ["start-devspace-backend", "FEATURES=agent-navigation"]
     # Inject a lightweight SSH server into the container (so your IDE can connect to the remote dev env)
     ssh:
       enabled: true


### PR DESCRIPTION
Scaling down the COO no longer works, as it disables all COO-manged consoleplugins.
Remove these lines from devspace.yaml so devspace can be used without the COO.
Also remove un-necessary sync files to speed up devspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment synchronization by waiting for the initial sync to complete.
  * Added automatic container restarts after file uploads to apply changes reliably.
  * Excluded source maps and unnecessary PatternFly modules from synchronization for faster, cleaner updates.
  * Corrected the backend startup feature configuration.
  * Simplified development and cleanup pipeline behavior for more predictable execution without unnecessary service scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->