### PR TITLE
NO-JIRA: fix: have devspace.yaml call backend directly to pass -features flag

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -21,16 +21,18 @@ dev:
     # Sync files between the local filesystem and the development container
     sync:
       - path: ./web/dist:/opt/app-root/web/dist
-        printLogs: true
         startContainer: true
+        printLogs: true
         waitInitialSync: true
-        excludePaths:
-          - "**/*.map"
-          - "**/node_modules_patternfly*"
-        onUpload:
-          restartContainer: true
-    command: ["make"]
-    args: ["start-devspace-backend", "FEATURES=agent-navigation"]
-    # Inject a lightweight SSH server into the container (so your IDE can connect to the remote dev env)
+    command: ["/opt/app-root/plugin-backend"]
+    args:
+      - -port=9443
+      - -cert=/var/serving-cert/tls.crt
+      - -key=/var/serving-cert/tls.key
+      - -plugin-config-path=/etc/plugin/config.yaml
+      - -static-path=/opt/app-root/web/dist
+      - -config-path=/opt/app-root/web/dist
+      - -features=agent-navigation
+
     ssh:
       enabled: true


### PR DESCRIPTION
The devspace image is too old to have the Makefile FEATURES variable,
skip make and run the backend directly for devspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved development environment startup and initial synchronization visibility by adjusting sync settings.
  * Updated the development backend launch configuration to use an explicit command with port, TLS certificate/key, plugin configuration, and static-content and config paths.
  * Enabled the `agent-navigation` capability in the development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->