### PR TITLE
NO-JIRA: fix: handle changes to alert URL syntax

### DIFF
--- a/web/src/__tests__/alert.spec.ts
+++ b/web/src/__tests__/alert.spec.ts
@@ -15,7 +15,7 @@ describe('AlertNode.fromURL', () => {
     },
     { url: 'monitoring/alerts', query: 'alert:alert:{}' },
     {
-      url: 'monitoring/alerts?alerts=alertname%3DKubePodCrashLooping%2Ccontainer%3Dbad-deployment%2Cnamespace%3Ddefault%2Cpod%3Dbad-pod',
+      url: 'monitoring/alerts?alertname=KubePodCrashLooping&container=bad-deployment&namespace=default&pod=bad-pod',
       query:
         'alert:alert:{"alertname":"KubePodCrashLooping","container":"bad-deployment","namespace":"default","pod":"bad-pod"}',
     },
@@ -42,36 +42,27 @@ describe('AlertNode.fromURL', () => {
   });
 });
 
-describe('AlertNode.fromURL raises error', () => {
-  it.each([
-    {
-      url: 'monitoring/alertrules/999',
-      error: 'unknown alert link: monitoring/alertrules/999: cannot find alertname',
-    },
-  ])('converts $url', ({ url, error }) => {
-    expect(() => new AlertDomain().linkToQuery(new URIRef(url))).toThrow(error);
-  });
-});
-
 describe('AlertDomain.fromQuery', () => {
   it.each([
     {
       query:
         'alert:alert:{"alertname":"KubePodCrashLooping","container":"bad-deployment","namespace":"default","pod":"bad-deployment"}',
-      url: 'monitoring/alerts?alerts=alertname%3DKubePodCrashLooping%2Ccontainer%3Dbad-deployment%2Cnamespace%3Ddefault%2Cpod%3Dbad-deployment',
+      url: 'monitoring/alerts/42?alertname=KubePodCrashLooping&container=bad-deployment&namespace=default&pod=bad-deployment',
+      idToName: new Map([['42', 'KubePodCrashLooping']]),
     },
     { query: 'alert:alert:{}', url: 'monitoring/alerts' },
-  ])('converts $query', ({ url, query }) => {
-    expect(new AlertDomain().queryToLink(Query.parse(query))).toEqual(new URIRef(url));
+  ])('converts $query', ({ url, query, idToName }) => {
+    expect(new AlertDomain(idToName).queryToLink(Query.parse(query))).toEqual(new URIRef(url));
   });
 
   it('Query => URL => Query', () => {
+    const domain = new AlertDomain(new Map([['42', 'KubePodCrashLooping']]));
     const query =
       'alert:alert:{"alertname":"KubePodCrashLooping","container":"bad-deployment","namespace":"default","pod":"bad-pod"}';
-    const got =
-      'monitoring/alerts?alerts=alertname%3DKubePodCrashLooping%2Ccontainer%3Dbad-deployment%2Cnamespace%3Ddefault%2Cpod%3Dbad-pod';
-    const want = new AlertDomain().queryToLink(Query.parse(query));
-    expect(want).toEqual(new URIRef(got));
-    expect(new AlertDomain().linkToQuery(want)).toEqual(Query.parse(query));
+    const url =
+      'monitoring/alerts/42?alertname=KubePodCrashLooping&container=bad-deployment&namespace=default&pod=bad-pod';
+    const want = domain.queryToLink(Query.parse(query));
+    expect(want).toEqual(new URIRef(url));
+    expect(domain.linkToQuery(want)).toEqual(Query.parse(query));
   });
 });

--- a/web/src/korrel8r/alert.ts
+++ b/web/src/korrel8r/alert.ts
@@ -1,10 +1,13 @@
-import { Class, Domain, Query, URIRef, keyValueList, parseKeyValueList } from './types';
+import { Class, Domain, Query, URIRef } from './types';
 
 export class AlertDomain extends Domain {
+  private nameToID: Map<string, string>;
+
   // Constructor takes an optional map of alert rule ID to name mappings.
   // Numeric IDs are used to refer to alerting rules with no alert parameters.
-  constructor(private idToName?: Map<string, string>) {
+  constructor(private idToName: Map<string, string> = new Map()) {
     super('alert');
+    this.nameToID = new Map(Array.from(idToName, ([key, value]) => [value, key]));
   }
 
   class(name: string): Class {
@@ -16,27 +19,18 @@ export class AlertDomain extends Domain {
   linkToQuery(link: URIRef): Query {
     const m = link.pathname.match(/monitoring\/(?:alerts|alertrules)(?:\/([^/]*))?/);
     if (!m) throw this.badLink(link);
-    const ruleID = m?.[1];
-    let selector: { [key: string]: string };
-    if (ruleID) {
-      // Search for alerts belonging to a specific alerting rule.
-      selector = Object.fromEntries(link.searchParams);
-      selector['alertname'] ||= this?.idToName?.get(ruleID); // Look up name from ID if missing
-      // Must have an alertname for a specific rule search.
-      if (!selector['alertname']) throw this.badLink(link, 'cannot find alertname');
-      nonLabelParams.forEach((key: string) => delete selector[key]);
-    } else {
-      // Generic alert search across rules. Empty selector is allowed - means "all alerts"
-      selector = parseKeyValueList(link.searchParams.get('alerts'));
-    }
+    const selector = Object.fromEntries(link.searchParams);
+    nonLabelParams.forEach((key: string) => delete selector[key]);
+    // Set name from ID if not already set. Name can be undefined to search all alerts.
+    selector['alertname'] ||= this.idToName.get(m?.[1]) || undefined;
     return new Query(this.class('alert'), JSON.stringify(selector));
   }
 
   queryToLink(query: Query): URIRef {
-    // Use "alerts" parameter to search for alerts of possibly mixed alertnames.
     try {
-      const selectors = keyValueList(JSON.parse(query.selector));
-      return new URIRef(`monitoring/alerts`, { alerts: selectors || undefined });
+      const selector = JSON.parse(query.selector);
+      const id = this.nameToID.get(selector['alertname']);
+      return new URIRef(`monitoring/alerts${id ? `/${id}` : ''}`, selector);
     } catch (e) {
       throw this.badQuery(query, e.toString());
     }


### PR DESCRIPTION
Alert URL syntax is simplified:
- Path always includes a numeric ID
- Use URL params directly, drop the old "&alert=a=b,x=y" parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert URL parsing and query parameter handling.
  * Alert links now preserve alert IDs and names during navigation.
  * Alert URLs use clearer, alert-specific paths when a recognized alert is selected.
  * Removed unnecessary encoding from alert query parameters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->