### PR TITLE
NO-JIRA: build: fixes to devspace setup

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -16,23 +16,24 @@ dev:
     labelSelector:
       # Use the instance selector that COO adds
       app.kubernetes.io/instance: troubleshooting-panel
-    # Replace the container image with this dev-optimized image (allows to skip image building during development)
+    # Replace the container image with this dev-optimized image (skip image building)
     devImage: quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:devspace
+
+    # Uncomment the following temporarily to force the cluster to pull the image.
+    #
+    # patches:
+    #   - op: replace
+    #     path: spec.containers[0].imagePullPolicy
+    #     value: Always
+
     # Sync files between the local filesystem and the development container
     sync:
       - path: ./web/dist:/opt/app-root/web/dist
         startContainer: true
         printLogs: true
         waitInitialSync: true
-    command: ["/opt/app-root/plugin-backend"]
-    args:
-      - -port=9443
-      - -cert=/var/serving-cert/tls.crt
-      - -key=/var/serving-cert/tls.key
-      - -plugin-config-path=/etc/plugin/config.yaml
-      - -static-path=/opt/app-root/web/dist
-      - -config-path=/opt/app-root/web/dist
-      - -features=agent-navigation
+    command: ["make"]
+    args: ["start-devspace-backend", "FEATURES=agent-navigation"]
 
     ssh:
       enabled: true

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -157,7 +157,7 @@ func filesHandler(root http.FileSystem) http.Handler {
 		filePath := r.URL.Path
 
 		// disable caching for plugin entry point
-		if strings.HasPrefix(filePath, "/plugin-entry.js") {
+		if strings.HasSuffix(filePath, ".js") {
 			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 			w.Header().Set("Expires", "0")
 		}


### PR DESCRIPTION
- use make target to run the backend (image is now up-to-date)
- disable server.go caching for all .js files - improve devspace stability

The devspace sync process is still not fully reliable. Disabling caching makes the errors temporary,
corrupted files aren't held in cache so problems usually clear up with a hard browser refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JavaScript assets now use no-cache headers, ensuring the latest scripts are loaded reliably.

* **Development Experience**
  * Improved development environment configuration with optional image pull policies and standardized backend startup.
  * Enabled agent navigation features during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->